### PR TITLE
fix: 게시판 오류 수정(자료공유, 사유서 제출)

### DIFF
--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -36,6 +36,11 @@
 .home-banner {
     width: 100%;
     overflow: hidden;
+    display: block;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
 }
 
 .banner-image {

--- a/src/Components/Home/Home.tsx
+++ b/src/Components/Home/Home.tsx
@@ -468,9 +468,9 @@ const Home: React.FC = () => {
                     </div>
                 </div>
             </header>
-            <div className="home-banner">
-            <img src={BANNER_IMAGE_URL} alt="banner-image" className="banner-image"/>
-            </div>
+            <button type="button" className="home-banner" onClick={() => navigate('/')} aria-label="홈으로 이동">
+                <img src={BANNER_IMAGE_URL} alt="banner-image" className="banner-image"/>
+            </button>
             <div className="home-content">
                 <Routes>
                     {/* home-content 전체 차지하는 경로 */}

--- a/src/Components/Home/Home.tsx
+++ b/src/Components/Home/Home.tsx
@@ -483,15 +483,16 @@ const Home: React.FC = () => {
                     {/* sidebar+main-area */}
                     <Route path="/" element={
                         <MainLayout sidebarProps={sidebarProps}>
-                            <JbigInfo />
-                            <div className="calendar-section-wrapper">
-                                <Calendar staffAuth={staffAuth}/>
-                                {staffAuth && (
-                                    <span className="add-event-text-home" onClick={handleAddEvent}>
-                                        일정 추가
-                                    </span>
-                                )}
-                            </div>
+                            <JbigInfo calendarSlot={
+                                <>
+                                    <Calendar staffAuth={staffAuth} compact />
+                                    {staffAuth && (
+                                        <span className="add-event-text-home" onClick={handleAddEvent}>
+                                            일정 추가
+                                        </span>
+                                    )}
+                                </>
+                            } />
                             <PostList boards={boards} isHome={true}/>
                             <PhotoAlbumSlider boards={boards} />
                         </MainLayout>

--- a/src/Components/Home/JbigInfo.css
+++ b/src/Components/Home/JbigInfo.css
@@ -28,14 +28,15 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    height: 44px;
-    padding: 0 14px;
-    border-radius: 999px;
+    height: 40px;
+    padding: 0 16px;
+    border-radius: 8px;
     font-weight: 800;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
     color: #fff;
-    background: linear-gradient(135deg, #2563eb, #1d4ed8);
-    box-shadow: 0 10px 24px rgba(37, 99, 235, 0.24);
+    background: #111827;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    box-shadow: 0 8px 18px rgba(17, 24, 39, 0.14);
     user-select: none;
 }
 

--- a/src/Components/Home/JbigInfo.css
+++ b/src/Components/Home/JbigInfo.css
@@ -1,27 +1,443 @@
 /* JBIG 정보 컨테이너 (메인 카드: 시선을 끄는 스타일) */
 .jbig-info-container {
     margin-bottom: var(--space-2xl);
-    border-radius: var(--radius-lg);
+    border-radius: 8px;
     position: relative;
     overflow: hidden;
-    background:
-        radial-gradient(1200px 500px at 0% 0%, rgba(37, 99, 235, 0.14), transparent 55%),
-        radial-gradient(900px 380px at 100% 0%, rgba(37, 99, 235, 0.16), transparent 55%),
-        linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.86));
+    background: #ffffff;
+    border: 1px solid rgba(15, 23, 42, 0.08);
     box-shadow: none;
-    /* 배경과 자연스럽게 섞이도록 테두리/프레임 느낌 제거 */
-    backdrop-filter: blur(8px);
     transform: translateZ(0);
+}
+
+.jbig-info-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+    gap: var(--space-xl);
+    align-items: start;
+    padding: var(--space-xl);
+}
+
+.jbig-cover {
+    position: relative;
+    width: 100%;
+    max-width: 360px;
+    aspect-ratio: 1 / 1;
+    overflow: hidden;
+    border-radius: 8px;
+    background: #f8fbff;
+    border: 1px solid rgba(37, 99, 235, 0.22);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+    isolation: isolate;
+}
+
+.jbig-cover::before {
+    content: "";
+    position: absolute;
+    inset: 18px;
+    border: 1px solid rgba(37, 99, 235, 0.2);
+    z-index: 0;
+}
+
+.jbig-cover-grid {
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(rgba(37, 99, 235, 0.11) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(37, 99, 235, 0.11) 1px, transparent 1px);
+    background-size: 28px 28px;
+    opacity: 0.42;
+    z-index: 0;
+}
+
+.jbig-cover-panel {
+    position: absolute;
+    left: auto;
+    right: 24px;
+    top: 24px;
+    width: 32%;
+    display: grid;
+    grid-template-columns: 1fr 0.72fr 0.44fr;
+    gap: 6px;
+    opacity: 0.55;
+    z-index: 1;
+}
+
+.jbig-cover-panel span {
+    height: 6px;
+    background: #2563eb;
+}
+
+.jbig-cover-panel span:nth-child(2) {
+    background: rgba(37, 99, 235, 0.46);
+}
+
+.jbig-cover-panel span:nth-child(3) {
+    background: rgba(37, 99, 235, 0.2);
+}
+
+.jbig-cover-wordmark {
+    position: absolute;
+    left: 34px;
+    right: 34px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: grid;
+    gap: 8px;
+    padding: 26px 22px;
+    background: #ffffff;
+    border: 2px solid #2563eb;
+    z-index: 3;
+}
+
+.jbig-cover-wordmark strong {
+    color: #0f172a;
+    font-size: clamp(3rem, 9vw, 4.6rem);
+    line-height: 0.9;
+    font-weight: 900;
+    letter-spacing: 0;
+}
+
+.jbig-cover-wordmark span {
+    color: #1d4ed8;
+    font-size: var(--font-size-xs);
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.jbig-cover-kicker {
+    justify-self: start;
+    padding: 4px 8px;
+    color: #ffffff !important;
+    background: #2563eb;
+}
+
+.jbig-cover-node {
+    position: absolute;
+    width: 9px;
+    height: 9px;
+    background: #2563eb;
+    border: 2px solid #ffffff;
+    box-shadow: 0 0 0 1px rgba(37, 99, 235, 0.34);
+    opacity: 0.58;
+    z-index: 1;
+}
+
+.node-a {
+    left: 30px;
+    top: 116px;
+}
+
+.node-b {
+    right: 34px;
+    top: 176px;
+}
+
+.node-c {
+    right: 48px;
+    bottom: 86px;
+}
+
+.jbig-cover-line {
+    position: absolute;
+    height: 2px;
+    background: #2563eb;
+    transform-origin: left center;
+    opacity: 0.2;
+    z-index: 0;
+}
+
+.line-a {
+    left: 36px;
+    top: 126px;
+    width: 160px;
+    transform: rotate(18deg);
+}
+
+.line-b {
+    right: 38px;
+    top: 186px;
+    width: 128px;
+    transform: rotate(76deg);
+}
+
+.line-c {
+    left: 34px;
+    bottom: 52px;
+    width: 170px;
+    background: rgba(37, 99, 235, 0.38);
+}
+
+.jbig-cover-metrics {
+    position: absolute;
+    left: 32px;
+    right: 32px;
+    bottom: 32px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    z-index: 2;
+}
+
+.jbig-cover-metrics span {
+    padding: 8px 0;
+    color: #1d4ed8;
+    background: #eff6ff;
+    border: 1px solid rgba(37, 99, 235, 0.22);
+    font-size: var(--font-size-xs);
+    font-weight: 900;
+    text-align: center;
+}
+
+.jbig-info-content {
+    min-width: 0;
+}
+
+.jbig-info-container {
+    display: flex;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    overflow: visible;
+}
+
+.jbig-cover {
+    max-width: none;
+    min-height: clamp(520px, 58vw, 660px);
+    aspect-ratio: auto;
+    margin: 0 auto;
+    padding: clamp(18px, 3vw, 26px);
+}
+
+.jbig-cover-main {
+    position: relative;
+    z-index: 5;
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto auto auto auto auto;
+    gap: clamp(8px, 1.1vw, 12px);
+    align-content: start;
+}
+
+.jbig-cover-content-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 0.82fr) minmax(280px, 1.18fr);
+    gap: 10px;
+    align-items: stretch;
+    min-height: 0;
+}
+
+.jbig-cover-info-stack {
+    display: grid;
+    gap: 8px;
+    align-content: start;
+    min-width: 0;
+}
+
+.jbig-cover-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.jbig-cover-title {
+    margin: 6px 0 0;
+    color: #0f172a;
+    font-size: clamp(2.8rem, 7vw, 4.8rem);
+    line-height: 0.86;
+    font-weight: 900;
+    letter-spacing: 0;
+}
+
+.jbig-cover-kicker {
+    display: inline-flex;
+    justify-self: start;
+    padding: 5px 9px;
+    color: #ffffff !important;
+    background: #2563eb;
+    font-size: clamp(0.62rem, 1.1vw, 0.78rem);
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.jbig-cover-badge {
+    flex: 0 0 auto;
+    padding: 8px 10px;
+    color: #1d4ed8;
+    background: #eff6ff;
+    border: 1px solid rgba(37, 99, 235, 0.24);
+    font-size: clamp(0.62rem, 1.1vw, 0.78rem);
+    font-weight: 900;
+}
+
+.jbig-cover-description {
+    margin: 0;
+    padding: 12px 14px;
+    color: #0f172a;
+    background: rgba(255, 255, 255, 0.9);
+    border: 2px solid #2563eb;
+    font-size: clamp(0.8rem, 1.25vw, 0.94rem);
+    line-height: 1.45;
+    font-weight: 700;
+    word-break: keep-all;
+}
+
+.jbig-cover-section {
+    display: grid;
+    gap: 6px;
+}
+
+.jbig-cover-section h3 {
+    margin: 0;
+    color: #0f172a;
+    font-size: clamp(0.78rem, 1.25vw, 0.96rem);
+    font-weight: 900;
+}
+
+.jbig-cover-section h3 span {
+    color: #2563eb;
+}
+
+.jbig-cover-acronym {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+}
+
+.jbig-cover-acronym div,
+.jbig-cover-activities span {
+    min-width: 0;
+    padding: 7px 8px;
+    background: #ffffff;
+    border: 1px solid rgba(37, 99, 235, 0.22);
+}
+
+.jbig-cover-acronym div {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 6px;
+    align-items: center;
+}
+
+.jbig-cover-acronym strong {
+    display: inline-flex;
+    width: 24px;
+    height: 24px;
+    align-items: center;
+    justify-content: center;
+    color: #ffffff;
+    background: #2563eb;
+    font-size: 0.82rem;
+    font-weight: 900;
+}
+
+.jbig-cover-acronym span,
+.jbig-cover-activities span {
+    color: #0f172a;
+    font-size: clamp(0.7rem, 1.1vw, 0.82rem);
+    font-weight: 900;
+    white-space: nowrap;
+}
+
+.jbig-cover-activities {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 6px;
+}
+
+.jbig-cover-activities span::before {
+    content: "";
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: 6px;
+    background: #2563eb;
+    vertical-align: 1px;
+}
+
+.jbig-cover-calendar {
+    position: relative;
+    min-width: 0;
+    min-height: 250px;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.94);
+    border: 1px solid rgba(37, 99, 235, 0.26);
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.06);
+}
+
+.jbig-cover-calendar-title {
+    margin-bottom: 6px;
+    color: #1d4ed8;
+    font-size: 0.7rem;
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+.jbig-cover-calendar .add-event-text-home {
+    padding: 6px 0 0;
+    font-size: 0.72rem;
+    font-weight: 900;
+}
+
+.jbig-cover-bottom {
+    display: grid;
+    grid-template-columns: minmax(0, 1.45fr) minmax(170px, 0.8fr);
+    gap: 8px;
+    align-items: end;
+}
+
+.jbig-cover-leaders {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+}
+
+.jbig-cover-leaders div,
+.jbig-cover-contact {
+    min-width: 0;
+    padding: 8px;
+    background: rgba(239, 246, 255, 0.92);
+    border: 1px solid rgba(37, 99, 235, 0.24);
+}
+
+.jbig-cover-leaders span,
+.jbig-cover-contact span {
+    display: block;
+    margin-bottom: 4px;
+    color: #1d4ed8;
+    font-size: 0.68rem;
+    font-weight: 900;
+}
+
+.jbig-cover-leaders strong,
+.jbig-cover-contact strong {
+    display: block;
+    overflow: hidden;
+    color: #0f172a;
+    font-size: clamp(0.76rem, 1.15vw, 0.9rem);
+    font-weight: 900;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.jbig-cover-leaders em,
+.jbig-cover-contact em {
+    display: block;
+    overflow: hidden;
+    margin-top: 3px;
+    color: #64748b;
+    font-size: 0.68rem;
+    font-style: normal;
+    font-weight: 800;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 /* Hero */
 .jbig-info-hero {
     position: relative;
-    padding: var(--space-xl);
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    gap: var(--space-md);
-    align-items: center;
+    padding: 0 0 var(--space-sm);
 }
 
 .jbig-info-badge {
@@ -76,7 +492,7 @@
 
 /* Body */
 .jbig-info-body {
-    padding: 0 var(--space-xl) var(--space-lg);
+    padding: 0;
 }
 
 .jbig-info-main {
@@ -221,7 +637,7 @@
 
 /* Contact 섹션 */
 .jbig-contact-section {
-    padding: 0 var(--space-xl) var(--space-xl);
+    padding: var(--space-lg) 0 0;
 }
 
 .jbig-contact-title {
@@ -252,10 +668,27 @@
 
 /* 모바일 스타일 */
 @media (max-width: 767px) {
-    .jbig-info-hero {
+    .jbig-info-layout {
         grid-template-columns: 1fr;
-        gap: var(--space-sm);
+        gap: var(--space-lg);
         padding: var(--space-lg);
+    }
+
+    .jbig-cover {
+        max-width: 100%;
+    }
+
+    .jbig-cover-content-grid,
+    .jbig-cover-bottom {
+        grid-template-columns: 1fr;
+    }
+
+    .jbig-cover-leaders {
+        grid-template-columns: 1fr;
+    }
+
+    .jbig-info-hero {
+        padding: 0 0 var(--space-sm);
     }
 
     .jbig-info-hero-icon {

--- a/src/Components/Home/JbigInfo.tsx
+++ b/src/Components/Home/JbigInfo.tsx
@@ -1,8 +1,12 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useState } from "react";
 import "./JbigInfo.css";
 import { fetchSiteSettings, SiteSettings } from "../../API/req";
 
-const JbigInfo: React.FC = () => {
+interface JbigInfoProps {
+    calendarSlot?: ReactNode;
+}
+
+const JbigInfo: React.FC<JbigInfoProps> = ({ calendarSlot }) => {
     // 하드코딩 제거
     const [settings, setSettings] = useState<SiteSettings>({
         notion_page_id: '',
@@ -66,99 +70,91 @@ const JbigInfo: React.FC = () => {
 
     return (
         <div className="jbig-info-container">
-            <div className="jbig-info-hero">
-                <div className="jbig-info-badge" aria-hidden="true">
-                    JBIG
+            <section className="jbig-cover" aria-label="JBIG 대문">
+                <div className="jbig-cover-grid" aria-hidden="true" />
+                <div className="jbig-cover-panel" aria-hidden="true">
+                    <span />
+                    <span />
+                    <span />
                 </div>
-                <div className="jbig-info-hero-text">
-                    <div className="jbig-info-kicker">JBNU Big Data & AI Group</div>
-                    <div className="jbig-info-title">
-                        <span className="jbig-info-title-strong">JBIG</span>은 데이터·AI 학술 교류 모임입니다
-                    </div>
-                </div>
-                <div className="jbig-info-hero-icon" aria-hidden="true">
-                    💡
-                </div>
-            </div>
+                <div className="jbig-cover-node node-a" aria-hidden="true" />
+                <div className="jbig-cover-node node-b" aria-hidden="true" />
+                <div className="jbig-cover-node node-c" aria-hidden="true" />
+                <div className="jbig-cover-line line-a" aria-hidden="true" />
+                <div className="jbig-cover-line line-b" aria-hidden="true" />
+                <div className="jbig-cover-line line-c" aria-hidden="true" />
 
-            <div className="jbig-info-body">
-                <p className="jbig-info-main">{highlightedDescription}</p>
-
-                <div className="jbig-acronym-section">
-                    <div className="jbig-section-title">
-                        <span className="jbig-section-title-strong">JBIG</span>가 무슨 약자인가요?
+                <div className="jbig-cover-main">
+                    <div className="jbig-cover-header">
+                        <div>
+                            <div className="jbig-cover-kicker">JBNU Big Data & AI Group</div>
+                            <h2 className="jbig-cover-title">JBIG</h2>
+                        </div>
+                        <div className="jbig-cover-badge">DATA / AI</div>
                     </div>
-                    <div className="jbig-acronym-chips" role="list">
-                        <div className="jbig-acronym-chip" role="listitem">
-                            <span className="jbig-acronym-letter">J</span>
-                            <span className="jbig-acronym-word">JBNU</span>
+
+                    <p className="jbig-cover-description">
+                        {highlightedDescription}
+                    </p>
+
+                    <div className="jbig-cover-content-grid">
+                        <div className="jbig-cover-info-stack">
+                            <div className="jbig-cover-section">
+                                <h3><span>JBIG</span>가 무슨 약자인가요?</h3>
+                                <div className="jbig-cover-acronym" role="list">
+                                    <div role="listitem"><strong>J</strong><span>JBNU</span></div>
+                                    <div role="listitem"><strong>B</strong><span>Big Data</span></div>
+                                    <div role="listitem"><strong>I</strong><span>AI</span></div>
+                                    <div role="listitem"><strong>G</strong><span>Group</span></div>
+                                </div>
+                            </div>
+
+                            <div className="jbig-cover-section">
+                                <h3>우리가 하는 활동</h3>
+                                <div className="jbig-cover-activities" role="list">
+                                    <span role="listitem">데이터 사이언스</span>
+                                    <span role="listitem">딥러닝</span>
+                                    <span role="listitem">머신러닝</span>
+                                    <span role="listitem">AI</span>
+                                </div>
+                            </div>
                         </div>
-                        <div className="jbig-acronym-chip" role="listitem">
-                            <span className="jbig-acronym-letter">B</span>
-                            <span className="jbig-acronym-word">Big Data</span>
+
+                        {calendarSlot && (
+                            <div className="jbig-cover-calendar">
+                                <div className="jbig-cover-calendar-title">Calendar</div>
+                                {calendarSlot}
+                            </div>
+                        )}
+                    </div>
+
+                    <div className="jbig-cover-bottom">
+                        <div className="jbig-cover-leaders">
+                            <div>
+                                <span>회장</span>
+                                <strong>{settings.jbig_president}</strong>
+                                <em>{settings.jbig_president_dept}</em>
+                            </div>
+                            <div>
+                                <span>부회장</span>
+                                <strong>{settings.jbig_vice_president}</strong>
+                                <em>{settings.jbig_vice_president_dept}</em>
+                            </div>
+                            <div>
+                                <span>지도 교수</span>
+                                <strong>{settings.jbig_advisor}</strong>
+                                <em>{settings.jbig_advisor_dept}</em>
+                            </div>
                         </div>
-                        <div className="jbig-acronym-chip" role="listitem">
-                            <span className="jbig-acronym-letter">I</span>
-                            <span className="jbig-acronym-word">AI</span>
-                        </div>
-                        <div className="jbig-acronym-chip" role="listitem">
-                            <span className="jbig-acronym-letter">G</span>
-                            <span className="jbig-acronym-word">Group</span>
+
+                        <div className="jbig-cover-contact">
+                            <span>Contact</span>
+                            <strong>회장 {settings.jbig_president}</strong>
+                            <em>{settings.jbig_email}</em>
                         </div>
                     </div>
                 </div>
-
-                <div className="jbig-activities-section">
-                    <div className="jbig-section-title">우리가 하는 활동</div>
-                    <div className="jbig-activity-chips" role="list">
-                        <div className="jbig-activity-chip" role="listitem">
-                            <span className="jbig-activity-dot" aria-hidden="true" />
-                            데이터 사이언스
-                        </div>
-                        <div className="jbig-activity-chip" role="listitem">
-                            <span className="jbig-activity-dot" aria-hidden="true" />
-                            딥러닝
-                        </div>
-                        <div className="jbig-activity-chip" role="listitem">
-                            <span className="jbig-activity-dot" aria-hidden="true" />
-                            머신러닝
-                        </div>
-                        <div className="jbig-activity-chip" role="listitem">
-                            <span className="jbig-activity-dot" aria-hidden="true" />
-                            AI
-                        </div>
-                    </div>
-                </div>
-
-                <div className="jbig-leaders">
-                    <div className="jbig-leader-line">
-                        <span className="jbig-leader-label">회장</span>
-                        <span className="jbig-leader-value">
-                            {settings.jbig_president} <span className="jbig-leader-meta">({settings.jbig_president_dept})</span>
-                        </span>
-                    </div>
-                    <div className="jbig-leader-line">
-                        <span className="jbig-leader-label">부회장</span>
-                        <span className="jbig-leader-value">
-                            {settings.jbig_vice_president} <span className="jbig-leader-meta">({settings.jbig_vice_president_dept})</span>
-                        </span>
-                    </div>
-                    <div className="jbig-leader-line">
-                        <span className="jbig-leader-label">지도 교수</span>
-                        <span className="jbig-leader-value">
-                            {settings.jbig_advisor} <span className="jbig-leader-meta">({settings.jbig_advisor_dept})</span>
-                        </span>
-                    </div>
-                </div>
-            </div>
-            
-            <div className="jbig-contact-section">
-                <h3 className="jbig-contact-title">📞 <strong>Contact</strong></h3>
-                <hr className="jbig-divider" />
-                <p className="jbig-contact-text">👑 <strong>회장 {settings.jbig_president}</strong></p>
-                <p className="jbig-contact-text">📧 e-mail : {settings.jbig_email}</p>
-                <p className="jbig-contact-quote">"이메일로 연락 주시면 빠른 시일 내에 연락드리겠습니다!"</p>
-            </div>
+            </section>
         </div>
     );
 };

--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -787,8 +787,12 @@ const PostDetail: React.FC = () => {
 
     if (!post) return <div className="postdetail-container">로딩 중...</div>;
 
-    const isFormBoard = 
-    (post.board_id && (Number(post.board_id) === 4 || Number(post.board_id) === 9));
+    const isFormBoard =
+        post.board_type === 3 ||
+        post.board.includes("사유서") ||
+        post.board.includes("에러") ||
+        post.board.includes("피드백") ||
+        post.board.includes("제보");
 
     return (
         <div className="postdetail-container has-floating-like">

--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -75,7 +75,11 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
     const { showAlert, showConfirm } = useAlert();
 
     const BOARD_LIST = useMemo(() => boards.flatMap((sec) => sec.boards), [boards]);
-    const isPhotoBoard = !!(selectedBoard && (selectedBoard.board_type === 4 || selectedBoard.name === "사진첩"));
+    const activeBoard = useMemo(
+        () => selectedBoard || BOARD_LIST.find((b) => b.id === Number(category)) || null,
+        [selectedBoard, BOARD_LIST, category]
+    );
+    const isPhotoBoard = !!(activeBoard && (activeBoard.board_type === 4 || activeBoard.name === "사진첩"));
 
     const filteredBoardList = useMemo(() => {
         if (staffAuth) return BOARD_LIST;
@@ -100,16 +104,17 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
     const isImageFileName = (name: string) => isImageByName(name);
     const formatBytes = (n?: number) => n ? `${(n / 1024 / 1024).toFixed(2)} MB` : "";
 
-    const isFeedbackBoard = selectedBoard &&
-        (selectedBoard.name.includes('에러') || selectedBoard.name.includes('피드백') || selectedBoard.name.includes('제보'));
+    const isFeedbackBoard = activeBoard &&
+        (activeBoard.name.includes('에러') || activeBoard.name.includes('피드백') || activeBoard.name.includes('제보'));
+    const isAbsenceBoard = !!(activeBoard && (activeBoard.board_type === 3 || activeBoard.name.includes("사유서")));
 
-    const boardTags = selectedBoard?.available_tags ?? [];
-    const isBragBoard = selectedBoard?.name === BRAG_BOARD_NAME;
+    const boardTags = activeBoard?.available_tags ?? [];
+    const isBragBoard = activeBoard?.name === BRAG_BOARD_NAME;
     const hasTags = boardTags.length > 0 && !isBragBoard;
     const isRecruitmentTag = selectedTag === '팀원모집';
 
-    const isStudyBoard = !isRecruitmentTag && !!selectedBoard?.name &&
-        STUDY_BOARD_NAME_KEYWORDS.every((keyword) => selectedBoard.name.includes(keyword));
+    const isStudyBoard = !isRecruitmentTag && !!activeBoard?.name &&
+        STUDY_BOARD_NAME_KEYWORDS.every((keyword) => activeBoard.name.includes(keyword));
 
     useEffect(() => {
         if (isPhotoBoard && content.trim()) {
@@ -201,15 +206,15 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
 
     // 게시판 접근 권한 체크
     useEffect(() => {
-        if (!staffAuth && selectedBoard &&
-            BLOCKED_BOARD_KEYWORDS.some((kw) => selectedBoard.name.toLowerCase().includes(kw.toLowerCase()))) {
+        if (!staffAuth && activeBoard &&
+            BLOCKED_BOARD_KEYWORDS.some((kw) => activeBoard.name.toLowerCase().includes(kw.toLowerCase()))) {
             showAlert({
                 message: "해당 게시판에는 글을 작성할 수 없습니다.",
                 type: 'warning',
                 onClose: () => navigate("/")
             });
         }
-    }, [selectedBoard, staffAuth, navigate, showAlert]);
+    }, [activeBoard, staffAuth, navigate, showAlert]);
 
     // URL에서 게시판 설정
     useEffect(() => {
@@ -221,11 +226,11 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
 
     // 자랑게시판에서는 태그/모집 상태 비활성화
     useEffect(() => {
-        if (selectedBoard?.name === BRAG_BOARD_NAME && selectedTag) {
+        if (activeBoard?.name === BRAG_BOARD_NAME && selectedTag) {
             setSelectedTag('');
             setRecruitmentData(null);
         }
-    }, [selectedBoard, selectedTag]);
+    }, [activeBoard, selectedTag]);
 
     // 초안 불러오기 (DB - 단일 버퍼)
     useEffect(() => {
@@ -298,9 +303,9 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                         await deleteDraft(accessToken).catch(() => {});
                     } else {
                         // DB에 저장 (upsert) - 현재 선택된 게시판도 함께 저장
-                        console.log('[Draft] Saving draft:', { board_id: selectedBoard?.id, title, content_length: content.length });
+                        console.log('[Draft] Saving draft:', { board_id: activeBoard?.id, title, content_length: content.length });
                         const result = await saveDraft({
-                            board_id: selectedBoard?.id || null,
+                            board_id: activeBoard?.id || null,
                             title,
                             content_md: content,
                             uploaded_paths: Array.from(uploadedPathsRef.current)
@@ -313,7 +318,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
             })();
         }, 2000);
         return () => clearTimeout(handler);
-    }, [title, content, selectedBoard, canUseDraft, accessToken]);
+    }, [title, content, activeBoard, canUseDraft, accessToken]);
 
     // 주기적 토큰 갱신 (활동 감지 시 45분마다 자동 갱신)
     useEffect(() => {
@@ -514,7 +519,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
             return true;
         }
 
-        if (category === '4') {
+        if (isAbsenceBoard) {
             if (/\| \*\*결석 날짜\*\* \|\s*\|/.test(content)) { showAlert({ message: "결석 날짜를 입력하세요.", type: 'warning' }); return false; }
             if (/\| \*\*결석 사유\*\* \|\s*(<br \/>)?\s*\|/.test(content)) { showAlert({ message: "결석 사유를 입력하세요.", type: 'warning' }); return false; }
         } else if (isFeedbackBoard) {
@@ -564,7 +569,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
             }); 
             return; 
         }
-        if (!selectedBoard && !isEdit) { showAlert({ message: "게시판을 선택하세요.", type: 'warning' }); return; }
+        if (!activeBoard && !isEdit) { showAlert({ message: "게시판을 선택하세요.", type: 'warning' }); return; }
         if (!validateForm()) { return; }
 
         inFlightRef.current = true;
@@ -576,11 +581,11 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
             if (isEdit && postIdNumber) {
                 await modifyPost(postIdNumber, {
                     title, content_md: content, attachment_paths: attachments,
-                    ...(selectedBoard ? { board_id: selectedBoard.id } : {}),
+                    ...(activeBoard ? { board_id: activeBoard.id } : {}),
                     is_anonymous: !showRealName,
                 }, accessToken);
                 savedRef.current = true;
-                navigate(`/board/${selectedBoard?.id ?? Number(category)}/${postIdNumber}`);
+                navigate(`/board/${activeBoard?.id ?? Number(category)}/${postIdNumber}`);
                 return;
             }
 
@@ -596,7 +601,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                     show_applicants: recruitmentData.show_applicants,
                 };
             }
-            const res = await createPost(selectedBoard!.id, postPayload, accessToken);
+            const res = await createPost(activeBoard!.id, postPayload, accessToken);
             if (res?.unauthorized) { 
                 showAlert({
                     message: "인증에 문제가 있습니다. 다시 로그인해주세요.",
@@ -611,7 +616,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                 await deleteDraft(accessToken).catch(() => {});
             }
             savedRef.current = true;
-            navigate(`/board/${selectedBoard!.id}`);
+            navigate(`/board/${activeBoard!.id}`);
         } catch (err) {
             showAlert({ message: err instanceof Error ? err.message : "저장 중 오류가 발생했습니다.", type: 'error' });
         } finally {
@@ -675,10 +680,10 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
 
     return (
         <form className="postwrite-form" onSubmit={handleSubmit} style={{ overflow: "hidden" }}>
-            {category !== '4' && (
+            {!isAbsenceBoard && (
                 <div className="postwrite-row">
                     <label>게시판</label>
-                    <select className="board-select" value={selectedBoard?.id ?? ""}
+                    <select className="board-select" value={activeBoard?.id ?? ""}
                         onChange={(e) => setSelectedBoard(filteredBoardList.find((b) => b.id === Number(e.target.value)) || null)}>
                         <option value="" hidden>게시판 선택</option>
                         {filteredBoardList.map((b) => <option key={b.id} value={b.id}>{b.name}</option>)}
@@ -715,7 +720,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                     placeholder={
                         isPhotoBoard
                             ? "사진 제목을 입력하세요"
-                            : category === '4'
+                            : isAbsenceBoard
                                 ? "[X주차] 결석사유서 OOO"
                                 : isFeedbackBoard
                                     ? "에러/피드백 제보 제목을 입력하세요"
@@ -736,7 +741,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                         setRecruitmentData={setRecruitmentData}
                         initialRecruitmentData={recruitmentData}
                     />
-                ) : category === '4' ? (
+                ) : isAbsenceBoard ? (
                     <AbsenceForm setContent={setContent} initialContent={content} />
                 ) : isFeedbackBoard ? (
                     <FeedbackForm setContent={setContent} initialContent={content} />

--- a/src/Components/Utils/Calendar/Calendar.css
+++ b/src/Components/Utils/Calendar/Calendar.css
@@ -1,3 +1,44 @@
 .popover {
     white-space: nowrap;   /* 줄바꿈 금지 */
 }
+
+.calendar-shell {
+    width: 100%;
+    padding: 12px 0 0;
+}
+
+.calendar-shell #calendar {
+    width: 100%;
+    max-width: 760px;
+    margin: 0 auto;
+    font-size: 0.9rem;
+}
+
+.calendar-shell .fc-toolbar {
+    margin-bottom: 10px;
+}
+
+.calendar-shell .fc-toolbar h2 {
+    font-size: 1.25rem;
+}
+
+.calendar-shell .fc-day-header,
+.calendar-shell .fc-day-number,
+.calendar-shell .fc-event {
+    font-size: 0.82rem;
+}
+
+@media (max-width: 767px) {
+    .calendar-shell {
+        padding-top: 8px;
+    }
+
+    .calendar-shell #calendar {
+        max-width: 100%;
+        font-size: 0.82rem;
+    }
+
+    .calendar-shell .fc-toolbar h2 {
+        font-size: 1rem;
+    }
+}

--- a/src/Components/Utils/Calendar/Calendar.css
+++ b/src/Components/Utils/Calendar/Calendar.css
@@ -28,6 +28,107 @@
     font-size: 0.82rem;
 }
 
+.calendar-shell-compact {
+    height: 100%;
+    padding: 0;
+}
+
+.calendar-shell-compact #calendar {
+    max-width: 100%;
+    height: 100%;
+    font-size: 0.72rem;
+}
+
+.calendar-shell-compact .fc-toolbar {
+    display: grid;
+    grid-template-columns: 32px minmax(0, 1fr) 32px;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 6px;
+}
+
+.calendar-shell-compact .fc-left,
+.calendar-shell-compact .fc-center,
+.calendar-shell-compact .fc-right {
+    float: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.calendar-shell-compact .fc-left {
+    justify-content: flex-start;
+}
+
+.calendar-shell-compact .fc-right {
+    justify-content: flex-end;
+}
+
+.calendar-shell-compact .fc-toolbar h2 {
+    margin: 0;
+    color: #0f172a;
+    font-size: 0.9rem;
+    font-weight: 900;
+    line-height: 1.1;
+}
+
+.calendar-shell-compact .fc-button {
+    min-width: 28px;
+    height: 26px;
+    padding: 0;
+    border-color: rgba(37, 99, 235, 0.24);
+    background: #eff6ff;
+    color: #1d4ed8;
+    box-shadow: none;
+}
+
+.calendar-shell-compact .fc-view-container {
+    background: #ffffff;
+}
+
+.calendar-shell-compact .fc-view,
+.calendar-shell-compact .fc-view > table {
+    min-height: 210px;
+}
+
+.calendar-shell-compact .fc th,
+.calendar-shell-compact .fc td {
+    border-color: rgba(37, 99, 235, 0.16);
+}
+
+.calendar-shell-compact .fc-day-header {
+    padding: 3px 0;
+    color: #1d4ed8;
+    font-size: 0.64rem;
+    font-weight: 900;
+}
+
+.calendar-shell-compact .fc-day-number {
+    padding: 2px 4px;
+    color: #334155;
+    font-size: 0.64rem;
+    font-weight: 800;
+}
+
+.calendar-shell-compact .fc-basic-view .fc-body .fc-row {
+    min-height: 30px;
+}
+
+.calendar-shell-compact .fc-event {
+    margin: 0 1px 1px;
+    padding: 0 2px;
+    border: 0;
+    border-radius: 2px;
+    font-size: 0.58rem;
+    line-height: 1.2;
+}
+
+.calendar-shell-compact .fc-event-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 @media (max-width: 767px) {
     .calendar-shell {
         padding-top: 8px;

--- a/src/Components/Utils/Calendar/Calendar.tsx
+++ b/src/Components/Utils/Calendar/Calendar.tsx
@@ -15,9 +15,10 @@ import {useNavigate} from "react-router-dom";
 
 interface CalendarProps {
     staffAuth: boolean;
+    compact?: boolean;
 }
 
-const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
+const Calendar: React.FC<CalendarProps> = ({ staffAuth, compact = false }) => {
     const { signOutLocal, accessToken } = useUser();
     const { showAlert } = useAlert();
     const navigate = useNavigate();
@@ -47,10 +48,22 @@ const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
 
     useEffect(() => {
         const loadEvents = async () => {
-            try {
-                const events: CalendarEvent[] = await fetchCalendarEvents();
+            let events: CalendarEvent[] = [];
 
-                ($("#calendar") as any).fullCalendar({
+            try {
+                events = await fetchCalendarEvents();
+            } catch {
+                events = [];
+            }
+
+            try {
+                const $calendar = ($("#calendar") as any);
+
+                if ($calendar.data("fullCalendar")) {
+                    $calendar.fullCalendar("destroy");
+                }
+
+                $calendar.fullCalendar({
                     locale: "ko",
                     defaultView: "month",
                     header: {
@@ -64,7 +77,7 @@ const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
                     },
                     editable: false,
                     eventLimit: true,
-                    aspectRatio: window.innerWidth < 768 ? 1.1 : 1.65,
+                    aspectRatio: compact ? 1.08 : (window.innerWidth < 768 ? 1.1 : 1.65),
                     events,
                     eventClick: function (calEvent: any, jsEvent: MouseEvent) {
                         jsEvent.preventDefault();
@@ -196,16 +209,16 @@ const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
                         `);
                     }
                 });
-            } catch {
-                // 캘린더 이벤트 로드 실패 시 무시
+            } catch (error) {
+                console.error("Failed to initialize calendar:", error);
             }
         };
 
         loadEvents();
-    }, [staffAuth, accessToken, signOutLocal, navigate]);
+    }, [staffAuth, accessToken, signOutLocal, navigate, compact]);
 
     return (
-        <div className="calendar-shell">
+        <div className={`calendar-shell${compact ? " calendar-shell-compact" : ""}`}>
             <div id="calendar"></div>
         </div>
     );

--- a/src/Components/Utils/Calendar/Calendar.tsx
+++ b/src/Components/Utils/Calendar/Calendar.tsx
@@ -5,6 +5,7 @@ import "fullcalendar/dist/fullcalendar.css";
 import "fullcalendar";
 import "bootstrap/dist/css/bootstrap.min.css";
 import "bootstrap/dist/js/bootstrap.bundle.min.js";
+import "./Calendar.css";
 import { CalendarEvent}  from "../interfaces";
 import moment from "moment";
 import {deleteCalendarEvent, fetchCalendarEvents} from "../../../API/req";
@@ -63,6 +64,7 @@ const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
                     },
                     editable: false,
                     eventLimit: true,
+                    aspectRatio: window.innerWidth < 768 ? 1.1 : 1.65,
                     events,
                     eventClick: function (calEvent: any, jsEvent: MouseEvent) {
                         jsEvent.preventDefault();
@@ -203,8 +205,8 @@ const Calendar: React.FC<CalendarProps> = ({ staffAuth }) => {
     }, [staffAuth, accessToken, signOutLocal, navigate]);
 
     return (
-        <div style={{ padding: "30px 0 0 0", width: "100%" }}>
-            <div id="calendar" style={{ width: "100%", maxWidth: "900px", margin: "0 auto" }}></div>
+        <div className="calendar-shell">
+            <div id="calendar"></div>
         </div>
     );
 };


### PR DESCRIPTION
## 변경 내용
- 글쓰기 화면에서 게시판 ID 4를 사유서 제출로 하드코딩하던 분기를 제거했습니다.
- URL 게시판 ID에 맞는 실제 게시판 정보를 기준으로 자료공유/사유서 제출/피드백/사진첩 분기가 동작하도록 정리했습니다.
- 상세 화면의 폼 게시판 판정도 게시판 ID 대신 board_type/name 기반으로 변경했습니다.
- 홈 배너 이미지를 클릭하면 홈(`/`)으로 이동하도록 했습니다.
- 홈 캘린더의 최대 폭, 상단 간격, 타이틀/셀/이벤트 글자 크기와 aspect ratio를 줄였습니다.

## 확인
- npm run build 통과
- http://localhost:3000 응답 200 확인
- 기존 소스맵/ESLint 경고는 유지됩니다.