### PR TITLE
chore(storage): NCP 표현 제거 및 R2/CDN 폴백으로 정리

### DIFF
--- a/src/API/req.tsx
+++ b/src/API/req.tsx
@@ -643,7 +643,7 @@ export const fetchUserPosts = async (
 
 // 첨부파일 업로드
 
-// 첨부파일 업로드 (NCP Presigned URL 방식)
+// 첨부파일 업로드 (Presigned URL 방식)
 export const uploadAttachment = async (file: File, token: string): Promise<{ path: string; name: string; url?: string; message?: string }> => {
     let generateUrlResponse;
     try {
@@ -666,7 +666,7 @@ export const uploadAttachment = async (file: File, token: string): Promise<{ pat
             headers: { "Content-Type": file.type || "application/octet-stream" },
         });
     } catch {
-        return { path: "", name: file.name, message: "클라우드 스토리지(NCP) 업로드에 실패했습니다." };
+        return { path: "", name: file.name, message: "클라우드 스토리지 업로드에 실패했습니다." };
     }
 
     // 업로드 완료 후 public-read ACL 적용
@@ -687,7 +687,7 @@ export const uploadAttachment = async (file: File, token: string): Promise<{ pat
     };
 };
 
-// 업로드된 파일 삭제 (NCP)
+// 업로드된 파일 삭제 (스토리지)
 export const deleteUploadedFile = async (path: string, token: string): Promise<{ success: boolean; message?: string }> => {
     try {
         await axios.delete(`${BASE_URL}/api/boards/files/delete/`, {
@@ -1420,7 +1420,7 @@ export interface PopupItem {
 export interface PopupCreate {
     title: string;
     content: string;
-    image_path?: string;  // 생성/수정 시 NCP key 경로 전송
+    image_path?: string;  // 생성/수정 시 스토리지 key 경로 전송
     start_date: string;
     end_date: string;
     is_active?: boolean;

--- a/src/Components/Admin/Admin.tsx
+++ b/src/Components/Admin/Admin.tsx
@@ -369,7 +369,7 @@ function PopupManagement({ accessToken }: { accessToken: string }) {
         let finalImagePath = imageUrl;
 
         try {
-            // 새로운 이미지 파일이 있으면 NCP Object Storage에 업로드
+            // 새로운 이미지 파일이 있으면 오브젝트 스토리지에 업로드
             if (imageFile) {
                 const uploadResult = await uploadAttachment(imageFile, accessToken);
                 console.log('[Popup] Upload result:', uploadResult);

--- a/src/Components/Home/Home.tsx
+++ b/src/Components/Home/Home.tsx
@@ -33,9 +33,9 @@ import PopupSlider from "../Utils/PopupSlider";
 import PhotoAlbumSlider from "./PhotoAlbumSlider";
 import $ from "jquery";
 
-// 미디어(CDN) 베이스 URL. R2 + Cloudflare CDN 전환 시 REACT_APP_MEDIA_BASE_URL 만 교체.
-// 미설정 시 기존 NCP 퍼블릭 URL로 폴백 (전환 전에도 동작).
-const MEDIA_BASE_URL = (process.env.REACT_APP_MEDIA_BASE_URL || "https://kr.object.ncloudstorage.com/jbig").replace(/\/$/, "");
+// 미디어(CDN) 베이스 URL. 운영은 REACT_APP_MEDIA_BASE_URL 로 주입(R2 + Cloudflare CDN).
+// 미설정 시 CDN 커스텀 도메인으로 폴백.
+const MEDIA_BASE_URL = (process.env.REACT_APP_MEDIA_BASE_URL || "https://cdn.jbig.co.kr").replace(/\/$/, "");
 const BANNER_IMAGE_URL = `${MEDIA_BASE_URL}/static/banner.jpg`;
 
 const removeWidgetBot = () => {

--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -591,7 +591,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
         if (uploadedPathsRef.current.size === 0 || !accessToken) return;
 
         const usedKeys = new Set<string>();
-        // ncp-key:// 형식과 퍼블릭/CDN URL 형식(ncloud, cdn.jbig.co.kr 등) 모두 매칭
+        // ncp-key:// 키 형식과 퍼블릭/CDN URL 형식(cdn.jbig.co.kr 등) 모두 매칭
         Array.from(
             content.matchAll(/(?:ncp-key:\/\/|https?:\/\/[^\s)]+?\/)(uploads\/[^\s)]+)/g)
         ).forEach(m => usedKeys.add(m[1]));

--- a/src/Components/Utils/interfaces.tsx
+++ b/src/Components/Utils/interfaces.tsx
@@ -209,7 +209,7 @@ export interface UploadFile {
     file: File;
     url: string;
     id?: number;
-    path?: string;  // NCP에 업로드된 파일의 고유 키 (삭제 시 식별용)
+    path?: string;  // 스토리지에 업로드된 파일의 고유 키 (삭제 시 식별용)
 }
 
 export interface UserComment {


### PR DESCRIPTION
운영 미디어 스토리지가 Cloudflare R2 + CDN으로 전환되어 NCP 관련 표현을 정리합니다.

## 변경 사항
- **Home**: `MEDIA_BASE_URL` 폴백을 NCP 퍼블릭 URL(`kr.object.ncloudstorage.com/jbig`) → CDN 커스텀 도메인(`cdn.jbig.co.kr`)으로 교체.
- **req / interfaces / Admin / PostWrite**: 주석·에러 메시지의 NCP 표현을 일반 스토리지 표현으로 변경.

## 유지한 항목
- `ncp-key://` 키 마커: 기존 본문 데이터와의 호환을 위해 유지하는 내부 키입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhbXCivdQVGQRm5rWBo1eX)_