### PR TITLE
chore(storage): 내부 키 마커 ncp-key:// → media-key:// 정리

### DIFF
--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -156,7 +156,7 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                 return false;
             }
 
-            const imageMarkdown = `![${res.name}](${res.url || `ncp-key://${res.path}`})`;
+            const imageMarkdown = `![${res.name}](${res.url || `media-key://${res.path}`})`;
             
             // 커서 위치에 이미지 삽입
             setContent(prev => {
@@ -591,9 +591,9 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
         if (uploadedPathsRef.current.size === 0 || !accessToken) return;
 
         const usedKeys = new Set<string>();
-        // ncp-key:// 키 형식과 퍼블릭/CDN URL 형식(cdn.jbig.co.kr 등) 모두 매칭
+        // media-key:// 키 형식과 퍼블릭/CDN URL 형식(cdn.jbig.co.kr 등) 모두 매칭
         Array.from(
-            content.matchAll(/(?:ncp-key:\/\/|https?:\/\/[^\s)]+?\/)(uploads\/[^\s)]+)/g)
+            content.matchAll(/(?:media-key:\/\/|https?:\/\/[^\s)]+?\/)(uploads\/[^\s)]+)/g)
         ).forEach(m => usedKeys.add(m[1]));
         attachments.forEach(a => usedKeys.add(a.path));
 
@@ -884,8 +884,8 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                                 components: {
                                     img: ({ src, alt, ...props }) => {
                                         let imageSrc = src;
-                                        if (src?.startsWith('ncp-key://')) {
-                                            const blobUrl = imageUrlMapRef.current.get(src.replace('ncp-key://', ''));
+                                        if (src?.startsWith('media-key://')) {
+                                            const blobUrl = imageUrlMapRef.current.get(src.replace('media-key://', ''));
                                             if (blobUrl) imageSrc = blobUrl;
                                         }
                                         return <img src={imageSrc} alt={alt} {...props} style={{ maxWidth: '100%' }} />;


### PR DESCRIPTION
본문 이미지 키 마커 생성/매칭/프리뷰 처리를 `ncp-key://` → `media-key://`로 변경합니다.

백엔드 마커 변경 및 데이터 마이그레이션(boards/0042)과 함께 동작합니다.

## 변경 사항
- `PostWrite.tsx`: 이미지 마크다운 삽입 시 키 마커, 사용중 키 추출 정규식, 에디터 프리뷰의 blob 매핑 처리를 모두 `media-key://` 기준으로 변경.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GhbXCivdQVGQRm5rWBo1eX)_