### PR TITLE
perf: 홈 로딩 워터폴 제거 및 모집 갱신 과다 조회 축소

### DIFF
--- a/src/Components/Home/Home.tsx
+++ b/src/Components/Home/Home.tsx
@@ -118,6 +118,10 @@ const Home: React.FC = () => {
             const semRaw = user?.semester;
             const sem = semRaw !== undefined && semRaw !== null ? Number(semRaw) : NaN;
 
+            // 게시판 목록은 로그인/퀴즈와 무관하므로 먼저 요청을 시작해 병렬로 진행한다.
+            // (기존에는 퀴즈 URL 응답을 기다린 뒤에야 게시판을 불러 워터폴이 발생했다.)
+            const boardsPromise = getBoards();
+
             if (!userName || !Number.isFinite(sem) || sem <= 0 || !accessToken) {
                 setUserName("");
                 setUserSemester(null);
@@ -142,7 +146,7 @@ const Home: React.FC = () => {
             }
 
             try {
-                const res = await getBoards();
+                const res = await boardsPromise;
                 setBoards(Array.isArray(res?.categories) ? res.categories : []);
                 setTotalCount(typeof res?.total_post_count === "number" ? res.total_post_count : 0);
             } catch {

--- a/src/Components/Home/Home.tsx
+++ b/src/Components/Home/Home.tsx
@@ -120,7 +120,9 @@ const Home: React.FC = () => {
 
             // 게시판 목록은 로그인/퀴즈와 무관하므로 먼저 요청을 시작해 병렬로 진행한다.
             // (기존에는 퀴즈 URL 응답을 기다린 뒤에야 게시판을 불러 워터폴이 발생했다.)
-            const boardsPromise = getBoards();
+            // 아래 await(퀴즈) 동안 이 프로미스가 거부되어도 unhandledrejection 이
+            // 뜨지 않도록 생성 시점에 catch 를 붙여 실패를 null 로 흡수한다.
+            const boardsPromise = getBoards().catch(() => null);
 
             if (!userName || !Number.isFinite(sem) || sem <= 0 || !accessToken) {
                 setUserName("");

--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo, useRef, useState, useCallback, memo} from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { PostDetailData, FormType } from "../Utils/interfaces";
-import {createComment, deleteComment, deletePost, fetchPostDetail, togglePostLike, toggleCommentLike, updateComment} from "../../API/req";
+import {createComment, deleteComment, deletePost, fetchPostDetail, fetchRecruitmentDetail, togglePostLike, toggleCommentLike, updateComment} from "../../API/req";
 import "./PostDetail.css";
 import "./PostDetail-mobile.css";
 import "./PostDetail-comments.css";
@@ -859,12 +859,12 @@ const PostDetail: React.FC = () => {
                     recruitment={post.recruitment}
                     postId={post.id}
                     onUpdate={() => {
-                        // 게시글 다시 로드
-                        fetchPostDetail(post.id, accessToken ?? undefined).then(raw => {
-                            const src = raw.post_data ?? raw;
+                        // 모집 정보만 갱신하면 되므로 본문+댓글 전체를 다시 받는
+                        // fetchPostDetail 대신 모집 상세만 가볍게 다시 불러온다.
+                        fetchRecruitmentDetail(post.id, accessToken ?? undefined).then(recruitment => {
                             setPost(prev => {
                                 if (!prev || typeof prev === "string") return prev;
-                                return { ...prev, recruitment: src.recruitment };
+                                return { ...prev, recruitment };
                             });
                         }).catch(() => {});
                     }}


### PR DESCRIPTION
## 개요
홈 진입 및 모집 상태 갱신 시 발생하던 불필요한 대기/과다 조회를 줄입니다. (백엔드 PR dev-JBIG/jbig_backend#29 과 함께 적용)

## 변경 내용
- **Home**: 게시판 목록 요청을 퀴즈 URL 응답을 기다린 뒤에 시작하던 워터폴을 제거. 로그인/퀴즈와 독립적이므로 먼저 요청을 띄워 병렬로 진행 → 로그인 사용자 첫 렌더에서 1 RTT 단축.
- **PostDetail**: 모집 상태 변경 후 본문+댓글 전체를 다시 받던 `fetchPostDetail` 대신, 모집 정보만 가볍게 불러오는 `fetchRecruitmentDetail`로 교체 → 갱신 페이로드 대폭 축소.

## 검증
- 프로젝트 TypeScript(4.9.5) 타입체크 클린

## 보류 항목
목록 첫 로드 이중 조회(F-3)는 `boards` 의존이 검색 스코프 판정에 실제로 쓰여, 무심코 제거 시 검색이 전체 검색으로 새는 회귀 위험이 있어 별도 검토로 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GsQBe7WDQzT2yd9R4sYYrn

---
_Generated by [Claude Code](https://claude.ai/code/session_01GsQBe7WDQzT2yd9R4sYYrn)_