### PR TITLE
chore: robots.txt에 sitemap.xml 선언 추가

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow: /@
+
+Sitemap: https://jbig.co.kr/sitemap.xml


### PR DESCRIPTION
## 개요
백엔드에 추가된 동적 `sitemap.xml`을 검색엔진이 자동 발견할 수 있도록 `robots.txt`에 `Sitemap:` 지시어를 추가합니다.

Closes #58
관련: dev-JBIG/jbig_backend#31, dev-JBIG/jbig_backend#32

## 변경 사항
`public/robots.txt`에 한 줄 추가:
```
Sitemap: https://jbig.co.kr/sitemap.xml
```

## 배포 시 필요
사이트맵이 실제로 응답하려면 nginx에서 `/sitemap.xml` → 백엔드 라우팅이 필요합니다(백엔드 PR 참고).