### PR TITLE
게시판 공개범위 관리 페이지 + 권한 게이트 첨부 다운로드

### DIFF
--- a/src/API/req.tsx
+++ b/src/API/req.tsx
@@ -700,6 +700,71 @@ export const deleteUploadedFile = async (path: string, token: string): Promise<{
     }
 };
 
+// 관리자: 게시판 목록(공개범위 포함) 조회
+export interface AdminBoard {
+    id: number;
+    name: string;
+    category: number;
+    category_name: string;
+    board_type: number;
+    form_type: number;
+    read_permission: "all" | "member" | "staff";
+    post_permission: string;
+    comment_permission: string;
+}
+
+export const getAdminBoards = async (token: string): Promise<AdminBoard[]> => {
+    const response = await axios.get(`${BASE_URL}/api/admin/boards/`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data as AdminBoard[];
+};
+
+// 관리자: 게시판 공개범위(read_permission) 변경
+export const updateBoardReadPermission = async (
+    token: string,
+    boardId: number,
+    readPermission: "all" | "member" | "staff"
+): Promise<{ success: boolean; message?: string }> => {
+    try {
+        await axios.patch(
+            `${BASE_URL}/api/admin/boards/${boardId}/`,
+            { read_permission: readPermission },
+            { headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` } }
+        );
+        return { success: true };
+    } catch (error: unknown) {
+        return { success: false, message: getErrorMessage(error, "게시판 공개범위 변경에 실패했습니다.") };
+    }
+};
+
+// 권한 게이트된 첨부파일 다운로드
+// 회원전용/스태프 게시판의 첨부는 공개 URL이 아니라 인증이 필요한 백엔드 엔드포인트로
+// 내려오므로, Authorization 헤더를 실은 요청으로 blob을 받아 브라우저 저장을 트리거한다.
+export const downloadGatedAttachment = async (
+    url: string,
+    fileName: string,
+    token: string
+): Promise<{ success: boolean; message?: string }> => {
+    try {
+        const response = await axios.get(url, {
+            headers: { Authorization: `Bearer ${token}` },
+            responseType: "blob",
+        });
+        const blobUrl = window.URL.createObjectURL(response.data);
+        const a = document.createElement("a");
+        a.href = blobUrl;
+        a.download = fileName || "download";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(blobUrl);
+        return { success: true };
+    } catch (error: unknown) {
+        return { success: false, message: getErrorMessage(error, "파일 다운로드에 실패했습니다.") };
+    }
+};
+
 // 토큰 갱신
 export const refreshTokenAPI = async (refresh: string) => {
     try {

--- a/src/Components/Admin/Admin.tsx
+++ b/src/Components/Admin/Admin.tsx
@@ -3,8 +3,8 @@ import { useNavigate } from "react-router-dom";
 import { useUser } from "../Utils/UserContext";
 import { useStaffAuth } from "../Utils/StaffAuthContext";
 import { useAlert } from "../Utils/AlertContext";
-import { 
-    fetchSiteSettings, 
+import {
+    fetchSiteSettings,
     updateSiteSettings,
     fetchAllPopups,
     createPopup,
@@ -12,7 +12,10 @@ import {
     deletePopup,
     PopupItem,
     PopupCreate,
-    uploadAttachment
+    uploadAttachment,
+    getAdminBoards,
+    updateBoardReadPermission,
+    AdminBoard
 } from "../../API/req";
 import { Menu, X, Plus, Edit2, Trash2, Eye, EyeOff } from "lucide-react";
 import "./Admin.css";
@@ -235,6 +238,112 @@ function Dashboard() {
                 <p style={{ color: '#666', marginTop: 12 }}>
                     왼쪽 메뉴에서 관리할 항목을 선택하세요.
                 </p>
+            </div>
+        </>
+    );
+}
+
+const READ_PERMISSION_OPTIONS: { value: "all" | "member" | "staff"; label: string }[] = [
+    { value: "all", label: "전체공개 (비회원 포함)" },
+    { value: "member", label: "회원전용 (로그인 회원)" },
+    { value: "staff", label: "스태프전용" },
+];
+
+function BoardManagement({ accessToken }: { accessToken: string }) {
+    const [boards, setBoards] = useState<AdminBoard[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [savingId, setSavingId] = useState<number | null>(null);
+    const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const data = await getAdminBoards(accessToken);
+                setBoards(data);
+            } catch {
+                setMessage({ type: 'error', text: '게시판 목록을 불러오는데 실패했습니다.' });
+            } finally {
+                setLoading(false);
+            }
+        };
+        load();
+    }, [accessToken]);
+
+    const handleChange = async (board: AdminBoard, value: "all" | "member" | "staff") => {
+        const prev = board.read_permission;
+        if (prev === value) return;
+        setSavingId(board.id);
+        setMessage(null);
+        // 낙관적 업데이트
+        setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, read_permission: value } : b)));
+        const res = await updateBoardReadPermission(accessToken, board.id, value);
+        if (res.success) {
+            setMessage({ type: 'success', text: `'${board.name}' 공개범위를 변경했습니다.` });
+        } else {
+            // 실패 시 롤백
+            setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, read_permission: prev } : b)));
+            setMessage({ type: 'error', text: res.message || '공개범위 변경에 실패했습니다.' });
+        }
+        setSavingId(null);
+    };
+
+    // 카테고리별 그룹핑 (서버가 category__id, name 순으로 정렬해 내려준다)
+    const grouped: { category: string; list: AdminBoard[] }[] = [];
+    boards.forEach((b) => {
+        const key = b.category_name || '기타';
+        const bucket = grouped.find((g) => g.category === key);
+        if (bucket) bucket.list.push(b);
+        else grouped.push({ category: key, list: [b] });
+    });
+
+    if (loading) {
+        return (
+            <>
+                <h2 className="admin-content-header">게시판 관리</h2>
+                <div className="admin-card"><p>로딩 중...</p></div>
+            </>
+        );
+    }
+
+    return (
+        <>
+            <h2 className="admin-content-header">게시판 관리</h2>
+            <div className="admin-card">
+                <h3 className="card-title">게시판 공개범위</h3>
+                <p className="form-hint" style={{ marginBottom: 16 }}>
+                    게시판별로 열람 범위를 지정합니다. 회원전용·스태프전용 게시판의 글과 첨부파일은
+                    비회원에게 노출되지 않으며, 첨부파일은 권한 확인 후에만 다운로드됩니다.
+                </p>
+                {message && (
+                    <div className={`admin-message ${message.type}`}>{message.text}</div>
+                )}
+                {grouped.map(({ category, list }) => (
+                    <div key={category} style={{ marginBottom: 20 }}>
+                        <h4 style={{ margin: '12px 0 8px', color: '#444' }}>{category}</h4>
+                        {list.map((board) => (
+                            <div
+                                key={board.id}
+                                style={{
+                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                    gap: 12, padding: '10px 0', borderBottom: '1px solid #eee',
+                                }}
+                            >
+                                <span style={{ fontWeight: 500 }}>{board.name}</span>
+                                <select
+                                    className="admin-input"
+                                    style={{ maxWidth: 220 }}
+                                    value={board.read_permission}
+                                    disabled={savingId === board.id}
+                                    onChange={(e) => handleChange(board, e.target.value as "all" | "member" | "staff")}
+                                >
+                                    {READ_PERMISSION_OPTIONS.map((opt) => (
+                                        <option key={opt.value} value={opt.value}>{opt.label}</option>
+                                    ))}
+                                </select>
+                            </div>
+                        ))}
+                    </div>
+                ))}
             </div>
         </>
     );
@@ -734,6 +843,7 @@ function Admin() {
 
     const adminMenus = [
         { id: "dashboard", name: "대시보드" },
+        { id: "boards", name: "게시판 관리" },
         { id: "settings", name: "사이트 설정" },
         { id: "popups", name: "팝업 관리" },
     ];
@@ -750,6 +860,8 @@ function Admin() {
     const renderContent = () => {
         if (!accessToken) return null;
         switch (currentPage) {
+            case "boards":
+                return <BoardManagement accessToken={accessToken} />;
             case "settings":
                 return <SettingsManagement accessToken={accessToken} />;
             case "popups":

--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useMemo, useRef, useState, useCallback, memo} from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { PostDetailData, FormType } from "../Utils/interfaces";
-import {createComment, deleteComment, deletePost, fetchPostDetail, togglePostLike, toggleCommentLike, updateComment} from "../../API/req";
+import {createComment, deleteComment, deletePost, fetchPostDetail, togglePostLike, toggleCommentLike, updateComment, downloadGatedAttachment} from "../../API/req";
 import "./PostDetail.css";
 import "./PostDetail-mobile.css";
 import "./PostDetail-comments.css";
@@ -99,6 +99,20 @@ const PostDetail: React.FC = () => {
     const { accessToken, authReady, signOutLocal } = useUser();
     const { staffAuth } = useStaffAuth();
     const { showAlert, showConfirm } = useAlert();
+
+    // 권한 게이트된 첨부(회원전용/스태프 게시판)는 공개 URL이 아니라 인증이 필요한
+    // 백엔드 엔드포인트로만 받을 수 있어, Authorization 헤더를 실은 요청으로 다운로드한다.
+    const handleGatedDownload = useCallback(async (e: React.MouseEvent, fileUrl: string, fileName: string) => {
+        e.preventDefault();
+        if (!accessToken) {
+            showAlert({ message: "로그인이 필요합니다.", type: 'warning' });
+            return;
+        }
+        const res = await downloadGatedAttachment(fileUrl, fileName, accessToken);
+        if (!res.success) {
+            showAlert({ message: res.message || "파일 다운로드에 실패했습니다.", type: 'error' });
+        }
+    }, [accessToken, showAlert]);
 
     
 
@@ -271,6 +285,7 @@ const PostDetail: React.FC = () => {
                                 fileUrl: item.url,
                                 fileName: item.name,
                                 fileType: ext(item.name),
+                                gated: !!item.gated,
                             };
                         }
                     }),
@@ -917,7 +932,12 @@ const PostDetail: React.FC = () => {
                         <ul>
                             {filtered.map(att => (
                                 <li key={att.id}>
-                                    <a href={att.fileUrl} target="_blank" rel="noopener noreferrer">
+                                    <a
+                                        href={att.fileUrl}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        onClick={att.gated ? (e) => handleGatedDownload(e, att.fileUrl, att.fileName) : undefined}
+                                    >
                                         {att.fileName}
                                         {att.fileType && (
                                             <span className="file-type"> ({att.fileType})</span>

--- a/src/Components/Utils/interfaces.tsx
+++ b/src/Components/Utils/interfaces.tsx
@@ -24,12 +24,17 @@ export interface Attachment {
     fileUrl: string;
     fileType?: string;
     fileSize?: number;
+    // 회원전용/스태프 게시판의 첨부는 권한 게이트된 백엔드 엔드포인트를 통해서만
+    // 받을 수 있다(공개 URL 아님). true면 인증 요청으로 다운로드해야 한다.
+    gated?: boolean;
 }
 
 // API에서 받는 첨부파일 객체 타입
 export interface AttachmentData {
     url: string;
     name: string;
+    size?: number;
+    gated?: boolean;
 }
 
 export interface Comment {
@@ -106,6 +111,8 @@ export interface Board {
     form_type?: number;
     available_tags?: string[];
     latest_post_created_at?: string | null;
+    // 공개범위: 'all'(전체공개) | 'member'(회원전용) | 'staff'(스태프전용)
+    read_permission?: 'all' | 'member' | 'staff';
 }
 
 // 모집 시스템 관련 인터페이스


### PR DESCRIPTION
## 배경

백엔드에 게시판 `member`(회원전용) 등급과 권한 게이트된 첨부 다운로드가 추가됨에 따라, 관리 UI와 다운로드 흐름을 맞춥니다. (백엔드 PR: dev-JBIG/jbig_backend)

## 변경 사항

**게시판 관리 페이지 신설**
- `/admin`에 **"게시판 관리"** 메뉴 추가. 게시판마다 공개범위를 드롭다운(전체공개 / 회원전용 / 스태프전용)으로 지정하면 `PATCH /api/admin/boards/<id>/` 로 저장(낙관적 업데이트 + 실패 시 롤백).
- API 클라이언트: `getAdminBoards`, `updateBoardReadPermission`.

**권한 게이트 첨부 다운로드**
- 회원전용/스태프 게시판 첨부는 공개 URL이 아니라 인증이 필요한 백엔드 엔드포인트로 내려옵니다(`gated` 플래그). `PostDetail`에서 이 첨부는 **Authorization 헤더를 실은 blob 요청**(`downloadGatedAttachment`)으로 다운로드하고, 전체공개 게시판 첨부는 기존 앵커 방식을 그대로 유지합니다.
- `Board`/`Attachment` 인터페이스에 `read_permission`/`gated` 추가, 첨부 매핑에 `gated` 반영.

## 검증
- `tsc --noEmit` 통과, 프로덕션 빌드(`react-scripts build`) 성공.

## 참고 (잔여)
- 비회원이 회원전용 게시판을 사이드바에서 여는 경우의 "로그인 필요" 안내 UX는 기존 staff 게시판과 동일하게 동작하며, 별도 잠금 표시는 후속 폴리시 항목입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxhkjnWijedoSWbkjpTXg)_