### PR TITLE
CI: 프로덕션 배포를 main 푸시로 제한

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -43,6 +43,9 @@ jobs:
   deploy:
     name: Deploy to Server
     needs: ci
+    # PR 이벤트에서는 빌드 검증(ci)만 수행하고, 실제 서버 배포는 main 푸시(머지)에서만 실행한다.
+    # 가드가 없으면 main으로 향하는 PR을 여는 것만으로 프로덕션에 배포된다.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Download build artifact


### PR DESCRIPTION
## 배경

감사 중 확인: `frontend.yml`의 `deploy` 잡에 브랜치/이벤트 가드가 없어 **main으로 향하는 PR을 여는 것만으로 프로덕션에 배포**됩니다 (실제로 PR #60이 머지 전에 배포됨).

## 변경

- `deploy` 잡에 `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` 가드 추가.
- PR에서는 빌드 검증(ci 잡)만 수행, 실제 배포는 머지(main 푸시) 시에만 실행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxhkjnWijedoSWbkjpTXg)_