### PR TITLE
비공개 게시판 잠금 표시 및 로그인 유도 UX

### DIFF
--- a/src/Components/Utils/MobileNav.tsx
+++ b/src/Components/Utils/MobileNav.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react";
-import { Menu, X, FileText, SquareCheckBig } from "lucide-react";
+import { Menu, X, FileText, SquareCheckBig, Lock } from "lucide-react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
-import { Section } from "./interfaces";
+import { Section, Board } from "./interfaces";
 import { getBoardIcon } from "./boardIcons";
+import { useUser } from "./UserContext";
+import { useAlert } from "./AlertContext";
 import "./MobileNav.css";
 
 interface MobileNavProps {
@@ -26,10 +28,31 @@ const MobileNav: React.FC<MobileNavProps> = ({
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
+  const { accessToken, user } = useUser();
+  const { showAlert } = useAlert();
 
   const handleNavigate = (path: string) => {
     navigate(path);
     setIsOpen(false);
+  };
+
+  // read_permission 미지정은 'all'(전체공개)로 취급해 하위호환 유지
+  const isBoardLocked = (board: Board): boolean =>
+    (board.read_permission === 'member' && !accessToken) ||
+    (board.read_permission === 'staff' && !(user?.is_staff));
+
+  const handleBoardClick = (board: Board) => {
+    if (board.read_permission === 'member' && !accessToken) {
+      showAlert({ message: '회원 전용 게시판입니다. 로그인 후 이용해주세요.', type: 'warning' });
+      handleNavigate("/signin");
+      return;
+    }
+    if (board.read_permission === 'staff' && !(user?.is_staff)) {
+      showAlert({ message: '스태프 전용 게시판입니다.', type: 'warning' });
+      setIsOpen(false);
+      return;
+    }
+    handleNavigate(`/board/${board.id}`);
   };
 
   const handleSearch = () => {
@@ -143,15 +166,23 @@ const MobileNav: React.FC<MobileNavProps> = ({
                   <div className="mobile-nav-section">
                     {section.boards.map((board) => {
                       const IconComponent = getBoardIcon(board.name);
+                      const locked = isBoardLocked(board);
                       return (
                         <div
                           key={board.id}
                           className="mobile-nav-item"
-                          onClick={() => handleNavigate(`/board/${board.id}`)}
+                          onClick={() => handleBoardClick(board)}
                         >
                           <div className="mobile-nav-item-content">
                             <IconComponent size={18} />
                             <span>{board.name}</span>
+                            {locked && (
+                              <Lock
+                                size={14}
+                                color="#999"
+                                style={{ marginLeft: 4, verticalAlign: "middle", flexShrink: 0 }}
+                              />
+                            )}
                           </div>
                         </div>
                       );

--- a/src/Components/Utils/Sidebar.tsx
+++ b/src/Components/Utils/Sidebar.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 import "../Home/Home.css"
-import { SidebarProps } from "./interfaces";
-import {FileText, SquareCheckBig } from "lucide-react";
+import { SidebarProps, Board } from "./interfaces";
+import {FileText, SquareCheckBig, Lock } from "lucide-react";
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { faDiscord, faGithub } from '@fortawesome/free-brands-svg-icons';
 import { getBoardIcon } from "./boardIcons";
+import { useUser } from "./UserContext";
+import { useAlert } from "./AlertContext";
 
 /**
  * 게시글이 24시간 이내에 작성되었는지 확인하는 함수
@@ -29,6 +31,27 @@ const Sidebar: React.FC<SidebarProps> = ({
                                              totalCount,
                                              navigate
                                          }) => {
+    const { accessToken, user } = useUser();
+    const { showAlert } = useAlert();
+
+    // read_permission 미지정은 'all'(전체공개)로 취급해 하위호환 유지
+    const isBoardLocked = (board: Board): boolean =>
+        (board.read_permission === 'member' && !accessToken) ||
+        (board.read_permission === 'staff' && !(user?.is_staff));
+
+    const handleBoardClick = (board: Board) => {
+        if (board.read_permission === 'member' && !accessToken) {
+            showAlert({ message: '회원 전용 게시판입니다. 로그인 후 이용해주세요.', type: 'warning' });
+            navigate("/signin");
+            return;
+        }
+        if (board.read_permission === 'staff' && !(user?.is_staff)) {
+            showAlert({ message: '스태프 전용 게시판입니다.', type: 'warning' });
+            return;
+        }
+        navigate(`/board/${board.id}`);
+    };
+
     return (
         <aside className="sidebar">
             <div className="sidebar-top-divider" />
@@ -69,14 +92,22 @@ const Sidebar: React.FC<SidebarProps> = ({
                         {section.boards.map((board) => {
                             const IconComponent = getBoardIcon(board.name);
                             const hasNewPost = isNewPost(board.latest_post_created_at);
+                            const locked = isBoardLocked(board);
                             return (
                                 <li
                                     key={board.id}
-                                    onClick={() => navigate(`/board/${board.id}`)}
+                                    onClick={() => handleBoardClick(board)}
                                 >
                                     <div className="board-item-content">
                                         <IconComponent className="board-icon" size={18} />
                                         {board.name}
+                                        {locked && (
+                                            <Lock
+                                                size={14}
+                                                color="#999"
+                                                style={{ marginLeft: 4, verticalAlign: "middle", flexShrink: 0 }}
+                                            />
+                                        )}
                                     </div>
                                     {hasNewPost && <span className="sidebar-new-badge">N</span>}
                                 </li>


### PR DESCRIPTION
## 배경

회원전용(`member`) 게시판 도입 후, 비회원이 사이드바에서 해당 게시판을 클릭하면 안내 없이 요청 실패만 보게 되는 UX 공백을 개선합니다. (#60 후속)

## 변경 사항

- **잠금 표시**: 현재 사용자가 읽을 수 없는 게시판(비로그인 상태의 회원전용, 비스태프의 스태프전용)에 자물쇠 아이콘 표시 — 데스크톱 `Sidebar.tsx` + 모바일 `MobileNav.tsx` 모두.
- **클릭 인터셉트**: 회원전용+비로그인 → "회원 전용 게시판입니다. 로그인 후 이용해주세요." 안내 후 `/signin` 이동. 스태프전용+비스태프 → 안내만(이동 없음).
- `read_permission` 미지정 게시판은 공개로 취급(하위호환). 백엔드가 `/api/categories/`에 이미 값을 내려주므로 데이터 흐름 변경 없음.

## 검증
- `tsc --noEmit` 통과, 프로덕션 빌드 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxhkjnWijedoSWbkjpTXg)_