### PR TITLE
글·댓글 작성 시 게시판 공개범위 안내 표시

### DIFF
--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -79,6 +79,20 @@ const LikePlusOne = memo(({ triggerKey, count, isLiked }: { triggerKey: number; 
     );
 });
 
+// 댓글 작성 위치에 표시할 공개범위 안내 문구 (board.read_scope 기준)
+const getCommentVisibilityHint = (scope?: 'all' | 'member' | 'staff'): string | null => {
+    switch (scope) {
+        case 'all':
+            return "이 게시판의 댓글은 비회원에게도 공개됩니다";
+        case 'member':
+            return "회원전용 게시판 — 댓글은 로그인한 회원에게만 보입니다";
+        case 'staff':
+            return "스태프전용 게시판입니다";
+        default:
+            return null;
+    }
+};
+
 const PostDetail: React.FC = () => {
     const { boardId, id: postId } = useParams();
     const navigate = useNavigate();
@@ -254,6 +268,7 @@ const PostDetail: React.FC = () => {
                     board_id: src.board_id || src.board?.id,
                     board_type: src.board?.board_type ?? 1,
                     form_type: src.board?.form_type ?? 0,
+                    board_read_scope: src.board?.read_scope,
                     author_semester: src.author_semester,
                     title: src.title || "",
                     content_html: src.content_html || "",
@@ -1217,6 +1232,11 @@ const PostDetail: React.FC = () => {
 
                 <div className="postdetail-comment-input-row">
                     <div style={{ display: 'flex', flexDirection: 'column', width: '100%', gap: '8px' }}>
+                        {getCommentVisibilityHint(post.board_read_scope) && (
+                            <span style={{ fontSize: '0.8em', color: '#888' }}>
+                                {getCommentVisibilityHint(post.board_read_scope)}
+                            </span>
+                        )}
                         <textarea
                             className="postdetail-comment-input"
                             rows={1}

--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -42,6 +42,20 @@ const extractKeyFromUrl = (url: string, fallback: string): string => {
 
 const isImageByName = (name: string) => /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
 
+// 선택한 게시판의 공개범위(read_permission)에 따른 안내 문구
+const getBoardVisibilityNotice = (perm?: 'all' | 'member' | 'staff'): string | null => {
+    switch (perm) {
+        case 'all':
+            return "🌐 전체공개 게시판 — 로그인하지 않은 방문자도 글과 첨부파일을 볼 수 있어요";
+        case 'member':
+            return "🔒 회원전용 게시판 — 로그인한 회원만 글과 첨부파일을 볼 수 있어요";
+        case 'staff':
+            return "🔒 스태프전용 게시판 — 스태프만 글을 볼 수 있어요";
+        default:
+            return null;
+    }
+};
+
 const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
     const [title, setTitle] = useState("");
     const [content, setContent] = useState("");
@@ -80,6 +94,14 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
         [selectedBoard, BOARD_LIST, category]
     );
     const isPhotoBoard = !!(activeBoard && (activeBoard.board_type === 4 || activeBoard.name === "사진첩"));
+
+    // 공개범위 안내: 수정 모드에서 activeBoard에 read_permission이 없을 수 있어 BOARD_LIST로 보완
+    const boardVisibilityNotice = useMemo(() => {
+        if (!activeBoard) return null;
+        const perm = activeBoard.read_permission
+            ?? BOARD_LIST.find((b) => b.id === activeBoard.id)?.read_permission;
+        return getBoardVisibilityNotice(perm);
+    }, [activeBoard, BOARD_LIST]);
 
     const filteredBoardList = useMemo(() => {
         if (staffAuth) return BOARD_LIST;
@@ -698,6 +720,23 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                         <option value="" hidden>게시판 선택</option>
                         {filteredBoardList.map((b) => <option key={b.id} value={b.id}>{b.name}</option>)}
                     </select>
+                </div>
+            )}
+
+            {boardVisibilityNotice && (
+                <div
+                    className="postwrite-visibility-notice"
+                    style={{
+                        fontSize: '12.5px',
+                        color: '#64748b',
+                        background: '#f8fafc',
+                        border: '1px solid #e2e8f0',
+                        borderRadius: '6px',
+                        padding: '7px 10px',
+                        marginTop: '-8px',
+                    }}
+                >
+                    {boardVisibilityNotice}
                 </div>
             )}
 

--- a/src/Components/Utils/interfaces.tsx
+++ b/src/Components/Utils/interfaces.tsx
@@ -77,6 +77,8 @@ export interface PostDetailData {
     board_id: number;
     board_type: number;
     form_type?: number;
+    // 게시판 공개범위(BoardSerializer.read_scope): 'all'(전체공개) | 'member'(회원전용) | 'staff'(스태프전용)
+    board_read_scope?: 'all' | 'member' | 'staff';
     title: string;
     content_html: string;
     content_md: string;


### PR DESCRIPTION
## 배경

회원전용 등급 도입 후, 글/댓글을 쓰는 사람이 "이 내용이 비회원에게도 보이는지"를 알 방법이 없었습니다. 작성 시점에 공개범위를 간략히 안내합니다. (#62 후속)

## 변경 사항

**글 작성 화면 (`PostWrite.tsx`)**
- 게시판 선택 직후 안내 박스 표시, 게시판 변경 시 즉시 갱신:
  - 🌐 전체공개 게시판 — 로그인하지 않은 방문자도 글과 첨부파일을 볼 수 있어요
  - 🔒 회원전용 게시판 — 로그인한 회원만 글과 첨부파일을 볼 수 있어요
  - 🔒 스태프전용 게시판 — 스태프만 글을 볼 수 있어요
- 수정 모드에서도 동작(BOARD_LIST 폴백). 공개범위 미상이면 미표시.

**댓글 입력창 (`PostDetail.tsx`)**
- 댓글창 위에 한 줄 힌트: "이 게시판의 댓글은 비회원에게도 공개됩니다" / "회원전용 게시판 — 댓글은 로그인한 회원에게만 보입니다" 등. 회원·비회원 댓글 경로 모두 표시.
- 글 상세 응답의 `board.read_scope`를 상태 매핑에 추가(`board_read_scope`).

## 검증
- `tsc --noEmit` 통과, 프로덕션 빌드 성공. 백엔드 변경 불필요(기존 노출 필드 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxhkjnWijedoSWbkjpTXg)_