### PR TITLE
공개범위 안내 오표기(사유서/제보) 및 게시판 전환 시 본문 손실 수정

### DIFF
--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -79,8 +79,19 @@ const LikePlusOne = memo(({ triggerKey, count, isLiked }: { triggerKey: number; 
     );
 });
 
-// 댓글 작성 위치에 표시할 공개범위 안내 문구 (board.read_scope 기준)
-const getCommentVisibilityHint = (scope?: 'all' | 'member' | 'staff'): string | null => {
+// 댓글 작성 위치에 표시할 공개범위 안내 문구
+// post_type(1=DEFAULT, 2=STAFF_ONLY, 3=JUSTIFICATION_LETTER)이 글 단위 접근 제한을
+// 결정하므로 board.read_scope보다 먼저 분기한다.
+const getCommentVisibilityHint = (
+    scope?: 'all' | 'member' | 'staff',
+    postType?: number
+): string | null => {
+    if (postType === 3) {
+        return "이 글과 댓글은 본인과 스태프만 볼 수 있습니다";
+    }
+    if (postType === 2) {
+        return "스태프만 볼 수 있는 글입니다";
+    }
     switch (scope) {
         case 'all':
             return "이 게시판의 댓글은 비회원에게도 공개됩니다";
@@ -1232,9 +1243,9 @@ const PostDetail: React.FC = () => {
 
                 <div className="postdetail-comment-input-row">
                     <div style={{ display: 'flex', flexDirection: 'column', width: '100%', gap: '8px' }}>
-                        {getCommentVisibilityHint(post.board_read_scope) && (
+                        {getCommentVisibilityHint(post.board_read_scope, post.post_type) && (
                             <span style={{ fontSize: '0.8em', color: '#888' }}>
-                                {getCommentVisibilityHint(post.board_read_scope)}
+                                {getCommentVisibilityHint(post.board_read_scope, post.post_type)}
                             </span>
                         )}
                         <textarea

--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -42,8 +42,27 @@ const extractKeyFromUrl = (url: string, fallback: string): string => {
 
 const isImageByName = (name: string) => /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(name);
 
-// 선택한 게시판의 공개범위(read_permission)에 따른 안내 문구
-const getBoardVisibilityNotice = (perm?: 'all' | 'member' | 'staff'): string | null => {
+// 게시판이 사용하는 본문 입력 폼 종류. (모집 태그 차원은 무시 — 태그는 게시판 변경 시 별도로 초기화됨)
+type FormKind = 'photo' | 'absence' | 'feedback' | 'study' | 'generic';
+const formKindOf = (board?: Board | null): FormKind => {
+    if (!board) return 'generic';
+    if (board.board_type === 4 || board.name === "사진첩") return 'photo';
+    if (board.form_type === FormType.ABSENCE) return 'absence';
+    if (board.form_type === FormType.FEEDBACK) return 'feedback';
+    if (!!board.name && STUDY_BOARD_NAME_KEYWORDS.every((kw) => board.name.includes(kw))) return 'study';
+    return 'generic';
+};
+
+// 선택한 게시판의 공개범위 안내 문구
+// board_type===3(JUSTIFICATION_LETTER: 사유서·에러/피드백 제보)은 read_permission이
+// 'all'로 저장돼 있어도 각 글은 본인+스태프로 제한되므로 board_type을 먼저 분기한다.
+const getBoardVisibilityNotice = (
+    perm?: 'all' | 'member' | 'staff',
+    boardType?: number
+): string | null => {
+    if (boardType === 3) {
+        return "🔒 제출한 글은 본인과 스태프만 볼 수 있어요";
+    }
     switch (perm) {
         case 'all':
             return "🌐 전체공개 게시판 — 로그인하지 않은 방문자도 글과 첨부파일을 볼 수 있어요";
@@ -98,9 +117,10 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
     // 공개범위 안내: 수정 모드에서 activeBoard에 read_permission이 없을 수 있어 BOARD_LIST로 보완
     const boardVisibilityNotice = useMemo(() => {
         if (!activeBoard) return null;
-        const perm = activeBoard.read_permission
-            ?? BOARD_LIST.find((b) => b.id === activeBoard.id)?.read_permission;
-        return getBoardVisibilityNotice(perm);
+        const fallbackBoard = BOARD_LIST.find((b) => b.id === activeBoard.id);
+        const perm = activeBoard.read_permission ?? fallbackBoard?.read_permission;
+        const boardType = activeBoard.board_type ?? fallbackBoard?.board_type;
+        return getBoardVisibilityNotice(perm, boardType);
     }, [activeBoard, BOARD_LIST]);
 
     const filteredBoardList = useMemo(() => {
@@ -716,7 +736,22 @@ const PostWrite: React.FC<PostWriteProps> = ({ boards = [] }) => {
                 <div className="postwrite-row">
                     <label>게시판</label>
                     <select className="board-select" value={activeBoard?.id ?? ""}
-                        onChange={(e) => setSelectedBoard(filteredBoardList.find((b) => b.id === Number(e.target.value)) || null)}>
+                        onChange={(e) => {
+                            const nextBoard = filteredBoardList.find((b) => b.id === Number(e.target.value)) || null;
+                            const currentKind = formKindOf(activeBoard);
+                            const nextKind = formKindOf(nextBoard);
+                            if (currentKind === nextKind || !content.trim()) {
+                                setSelectedBoard(nextBoard);
+                                return;
+                            }
+                            showConfirm({
+                                message: "게시판 작성 양식이 달라 작성 중인 본문이 초기화됩니다. 게시판을 변경할까요?",
+                                onConfirm: () => {
+                                    setContent("");
+                                    setSelectedBoard(nextBoard);
+                                },
+                            });
+                        }}>
                         <option value="" hidden>게시판 선택</option>
                         {filteredBoardList.map((b) => <option key={b.id} value={b.id}>{b.name}</option>)}
                     </select>


### PR DESCRIPTION
## 배경

#63 배포 후 사용자 테스트에서 발견된 두 문제 수정.

## 1. 사유서/제보 게시판에 "전체공개" 안내가 뜨던 문제

`board_type=3`(사유서제출, 에러/피드백 제보) 게시판은 비스태프 작성자가 자기 글에 접근해야 해서 `read_permission='all'`로 저장되지만, 실제 글은 **본인+스태프만** 볼 수 있습니다(post_type 단위 제한). 안내문이 read_permission만 보고 "🌐 전체공개"라고 표시해 폼 내 "본인과 관리자만 확인" 문구와 모순됐습니다.

- 작성 화면: `board_type===3`이면 → 「🔒 제출한 글은 본인과 스태프만 볼 수 있어요」
- 댓글 힌트: `post_type===3` → 「이 글과 댓글은 본인과 스태프만 볼 수 있습니다」, `post_type===2` → 「스태프만 볼 수 있는 글입니다」 (그 외는 기존 board 기준)

## 2. 게시판 전환 시 본문 잔류/파괴

스터디/소모임 홍보의 모집 템플릿이 다른 게시판으로 전환해도 본문에 남았고, 반대로 일반 게시판에서 쓰던 본문이 스터디 게시판 진입 시 템플릿으로 **말없이 덮여 사라졌습니다**.

- 게시판 select 변경 시 폼 종류(photo/absence/feedback/study/generic)를 비교해, **종류가 다르고 본문이 비어있지 않으면** 확인 다이얼로그(「게시판 작성 양식이 달라 작성 중인 본문이 초기화됩니다. 게시판을 변경할까요?」) 후 초기화. 취소하면 원래 게시판 유지(controlled select라 자동 복원). 같은 종류 간 전환은 기존대로 본문 유지.
- 이벤트 기반 처리라 수정 모드 초기 로드에는 영향 없음.

## 검증
- `tsc --noEmit` 통과, 프로덕션 빌드 성공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dxhkjnWijedoSWbkjpTXg)_