### PR TITLE
관리자 게시판 관리를 조회/작성/댓글 권한 매트릭스로 개편

### DIFF
--- a/src/API/req.tsx
+++ b/src/API/req.tsx
@@ -700,7 +700,10 @@ export const deleteUploadedFile = async (path: string, token: string): Promise<{
     }
 };
 
-// 관리자: 게시판 목록(공개범위 포함) 조회
+// 관리자: 게시판 목록(권한 매트릭스 포함) 조회
+export type BoardReadPermission = "all" | "member" | "author" | "staff";
+export type BoardTwoLevelPermission = "all" | "staff";
+
 export interface AdminBoard {
     id: number;
     name: string;
@@ -708,9 +711,9 @@ export interface AdminBoard {
     category_name: string;
     board_type: number;
     form_type: number;
-    read_permission: "all" | "member" | "staff";
-    post_permission: string;
-    comment_permission: string;
+    read_permission: BoardReadPermission;
+    post_permission: BoardTwoLevelPermission;
+    comment_permission: BoardTwoLevelPermission;
 }
 
 export const getAdminBoards = async (token: string): Promise<AdminBoard[]> => {
@@ -720,21 +723,21 @@ export const getAdminBoards = async (token: string): Promise<AdminBoard[]> => {
     return response.data as AdminBoard[];
 };
 
-// 관리자: 게시판 공개범위(read_permission) 변경
-export const updateBoardReadPermission = async (
+// 관리자: 게시판 권한(조회/작성/댓글) 변경 — 바꿀 필드만 부분 PATCH
+export const updateBoardPermissions = async (
     token: string,
     boardId: number,
-    readPermission: "all" | "member" | "staff"
+    patch: Partial<Pick<AdminBoard, "read_permission" | "post_permission" | "comment_permission">>
 ): Promise<{ success: boolean; message?: string }> => {
     try {
         await axios.patch(
             `${BASE_URL}/api/admin/boards/${boardId}/`,
-            { read_permission: readPermission },
+            patch,
             { headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` } }
         );
         return { success: true };
     } catch (error: unknown) {
-        return { success: false, message: getErrorMessage(error, "게시판 공개범위 변경에 실패했습니다.") };
+        return { success: false, message: getErrorMessage(error, "게시판 권한 변경에 실패했습니다.") };
     }
 };
 

--- a/src/Components/Admin/Admin.tsx
+++ b/src/Components/Admin/Admin.tsx
@@ -14,8 +14,10 @@ import {
     PopupCreate,
     uploadAttachment,
     getAdminBoards,
-    updateBoardReadPermission,
-    AdminBoard
+    updateBoardPermissions,
+    AdminBoard,
+    BoardReadPermission,
+    BoardTwoLevelPermission
 } from "../../API/req";
 import { Menu, X, Plus, Edit2, Trash2, Eye, EyeOff } from "lucide-react";
 import "./Admin.css";
@@ -243,11 +245,44 @@ function Dashboard() {
     );
 }
 
-const READ_PERMISSION_OPTIONS: { value: "all" | "member" | "staff"; label: string }[] = [
+const READ_PERMISSION_OPTIONS: { value: BoardReadPermission; label: string }[] = [
     { value: "all", label: "전체공개 (비회원 포함)" },
     { value: "member", label: "회원전용 (로그인 회원)" },
+    { value: "author", label: "본인+스태프" },
     { value: "staff", label: "스태프전용" },
 ];
+
+const TWO_LEVEL_OPTIONS: { value: BoardTwoLevelPermission; label: string }[] = [
+    { value: "all", label: "회원" },
+    { value: "staff", label: "스태프만" },
+];
+
+// 게시판 유형별로 선택 가능한 조회 범위와 안내 문구. 백엔드 BoardAdminSerializer의
+// validate_read_permission과 같은 규칙 — 사진첩(4)은 이미지 렌더링 특성상 전체공개만,
+// 사유서형(3)은 글 단위 잠금(본인+스태프)이 전제라 'author'로 고정된다.
+const getBoardPolicy = (board: AdminBoard) => {
+    if (board.board_type === 4) {
+        return {
+            readOptions: READ_PERMISSION_OPTIONS.filter((o) => o.value === "all"),
+            hint: "이미지 렌더링 특성상 전체공개만 지원해요",
+        };
+    }
+    if (board.board_type === 3) {
+        return {
+            readOptions: READ_PERMISSION_OPTIONS.filter((o) => o.value === "author"),
+            hint: "제출형 게시판 — 글은 작성자 본인과 스태프만 볼 수 있어요",
+        };
+    }
+    return { readOptions: READ_PERMISSION_OPTIONS, hint: null };
+};
+
+type PermissionField = "read_permission" | "post_permission" | "comment_permission";
+
+const PERMISSION_FIELD_LABELS: Record<PermissionField, string> = {
+    read_permission: "조회",
+    post_permission: "작성",
+    comment_permission: "댓글",
+};
 
 function BoardManagement({ accessToken }: { accessToken: string }) {
     const [boards, setBoards] = useState<AdminBoard[]>([]);
@@ -269,20 +304,20 @@ function BoardManagement({ accessToken }: { accessToken: string }) {
         load();
     }, [accessToken]);
 
-    const handleChange = async (board: AdminBoard, value: "all" | "member" | "staff") => {
-        const prev = board.read_permission;
+    const handleChange = async (board: AdminBoard, field: PermissionField, value: string) => {
+        const prev = board[field];
         if (prev === value) return;
         setSavingId(board.id);
         setMessage(null);
         // 낙관적 업데이트
-        setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, read_permission: value } : b)));
-        const res = await updateBoardReadPermission(accessToken, board.id, value);
+        setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, [field]: value } : b)));
+        const res = await updateBoardPermissions(accessToken, board.id, { [field]: value });
         if (res.success) {
-            setMessage({ type: 'success', text: `'${board.name}' 공개범위를 변경했습니다.` });
+            setMessage({ type: 'success', text: `'${board.name}' ${PERMISSION_FIELD_LABELS[field]} 권한을 변경했습니다.` });
         } else {
             // 실패 시 롤백
-            setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, read_permission: prev } : b)));
-            setMessage({ type: 'error', text: res.message || '공개범위 변경에 실패했습니다.' });
+            setBoards((bs) => bs.map((b) => (b.id === board.id ? { ...b, [field]: prev } : b)));
+            setMessage({ type: 'error', text: res.message || '권한 변경에 실패했습니다.' });
         }
         setSavingId(null);
     };
@@ -305,14 +340,18 @@ function BoardManagement({ accessToken }: { accessToken: string }) {
         );
     }
 
+    const selectStyle = { minWidth: 0 } as const;
+    const cellLabelStyle = { fontSize: 11, color: '#999', marginBottom: 2 } as const;
+
     return (
         <>
             <h2 className="admin-content-header">게시판 관리</h2>
             <div className="admin-card">
-                <h3 className="card-title">게시판 공개범위</h3>
+                <h3 className="card-title">게시판 권한</h3>
                 <p className="form-hint" style={{ marginBottom: 16 }}>
-                    게시판별로 열람 범위를 지정합니다. 회원전용·스태프전용 게시판의 글과 첨부파일은
-                    비회원에게 노출되지 않으며, 첨부파일은 권한 확인 후에만 다운로드됩니다.
+                    게시판별로 조회·작성·댓글 권한을 지정합니다. 조회의 '본인+스태프'는 회원이
+                    제출은 할 수 있지만 글은 작성자 본인과 스태프만 볼 수 있는 범위입니다.
+                    비공개 범위 게시판의 글과 첨부파일은 권한 확인 후에만 내려갑니다.
                 </p>
                 {message && (
                     <div className={`admin-message ${message.type}`}>{message.text}</div>
@@ -320,28 +359,70 @@ function BoardManagement({ accessToken }: { accessToken: string }) {
                 {grouped.map(({ category, list }) => (
                     <div key={category} style={{ marginBottom: 20 }}>
                         <h4 style={{ margin: '12px 0 8px', color: '#444' }}>{category}</h4>
-                        {list.map((board) => (
-                            <div
-                                key={board.id}
-                                style={{
-                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                    gap: 12, padding: '10px 0', borderBottom: '1px solid #eee',
-                                }}
-                            >
-                                <span style={{ fontWeight: 500 }}>{board.name}</span>
-                                <select
-                                    className="admin-input"
-                                    style={{ maxWidth: 220 }}
-                                    value={board.read_permission}
-                                    disabled={savingId === board.id}
-                                    onChange={(e) => handleChange(board, e.target.value as "all" | "member" | "staff")}
+                        {list.map((board) => {
+                            const policy = getBoardPolicy(board);
+                            const saving = savingId === board.id;
+                            return (
+                                <div
+                                    key={board.id}
+                                    style={{
+                                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                                        flexWrap: 'wrap', gap: 12, padding: '10px 0', borderBottom: '1px solid #eee',
+                                    }}
                                 >
-                                    {READ_PERMISSION_OPTIONS.map((opt) => (
-                                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                                    ))}
-                                </select>
-                            </div>
-                        ))}
+                                    <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 140 }}>
+                                        <span style={{ fontWeight: 500 }}>{board.name}</span>
+                                        {policy.hint && (
+                                            <span style={{ fontSize: 12, color: '#888' }}>🔒 {policy.hint}</span>
+                                        )}
+                                    </div>
+                                    <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                                        <div style={{ display: 'flex', flexDirection: 'column', width: 180 }}>
+                                            <span style={cellLabelStyle}>조회</span>
+                                            <select
+                                                className="admin-input"
+                                                style={selectStyle}
+                                                value={board.read_permission}
+                                                disabled={saving || policy.readOptions.length <= 1}
+                                                onChange={(e) => handleChange(board, 'read_permission', e.target.value)}
+                                            >
+                                                {policy.readOptions.map((opt) => (
+                                                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                        <div style={{ display: 'flex', flexDirection: 'column', width: 110 }}>
+                                            <span style={cellLabelStyle}>작성</span>
+                                            <select
+                                                className="admin-input"
+                                                style={selectStyle}
+                                                value={board.post_permission}
+                                                disabled={saving}
+                                                onChange={(e) => handleChange(board, 'post_permission', e.target.value)}
+                                            >
+                                                {TWO_LEVEL_OPTIONS.map((opt) => (
+                                                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                        <div style={{ display: 'flex', flexDirection: 'column', width: 110 }}>
+                                            <span style={cellLabelStyle}>댓글</span>
+                                            <select
+                                                className="admin-input"
+                                                style={selectStyle}
+                                                value={board.comment_permission}
+                                                disabled={saving}
+                                                onChange={(e) => handleChange(board, 'comment_permission', e.target.value)}
+                                            >
+                                                {TWO_LEVEL_OPTIONS.map((opt) => (
+                                                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                            );
+                        })}
                     </div>
                 ))}
             </div>

--- a/src/Components/Posts/PostDetail.tsx
+++ b/src/Components/Posts/PostDetail.tsx
@@ -83,7 +83,7 @@ const LikePlusOne = memo(({ triggerKey, count, isLiked }: { triggerKey: number; 
 // post_type(1=DEFAULT, 2=STAFF_ONLY, 3=JUSTIFICATION_LETTER)이 글 단위 접근 제한을
 // 결정하므로 board.read_scope보다 먼저 분기한다.
 const getCommentVisibilityHint = (
-    scope?: 'all' | 'member' | 'staff',
+    scope?: 'all' | 'member' | 'author' | 'staff',
     postType?: number
 ): string | null => {
     if (postType === 3) {
@@ -97,6 +97,8 @@ const getCommentVisibilityHint = (
             return "이 게시판의 댓글은 비회원에게도 공개됩니다";
         case 'member':
             return "회원전용 게시판 — 댓글은 로그인한 회원에게만 보입니다";
+        case 'author':
+            return "이 글과 댓글은 본인과 스태프만 볼 수 있습니다";
         case 'staff':
             return "스태프전용 게시판입니다";
         default:

--- a/src/Components/Posts/PostWrite.tsx
+++ b/src/Components/Posts/PostWrite.tsx
@@ -54,13 +54,13 @@ const formKindOf = (board?: Board | null): FormKind => {
 };
 
 // 선택한 게시판의 공개범위 안내 문구
-// board_type===3(JUSTIFICATION_LETTER: 사유서·에러/피드백 제보)은 read_permission이
-// 'all'로 저장돼 있어도 각 글은 본인+스태프로 제한되므로 board_type을 먼저 분기한다.
+// board_type===3(사유서·에러/피드백 제보)은 서버가 read_permission='author'로 관리하지만,
+// 구버전 캐시 데이터에 read_permission이 없을 수 있어 board_type도 함께 분기한다.
 const getBoardVisibilityNotice = (
-    perm?: 'all' | 'member' | 'staff',
+    perm?: 'all' | 'member' | 'author' | 'staff',
     boardType?: number
 ): string | null => {
-    if (boardType === 3) {
+    if (perm === 'author' || boardType === 3) {
         return "🔒 제출한 글은 본인과 스태프만 볼 수 있어요";
     }
     switch (perm) {

--- a/src/Components/Utils/MobileNav.tsx
+++ b/src/Components/Utils/MobileNav.tsx
@@ -37,12 +37,16 @@ const MobileNav: React.FC<MobileNavProps> = ({
   };
 
   // read_permission 미지정은 'all'(전체공개)로 취급해 하위호환 유지
+  // 'author'(본인+스태프) 게시판은 진입 자체는 회원 전체에게 열린다(제출·본인 글 확인용).
+  const requiresLogin = (board: Board): boolean =>
+    board.read_permission === 'member' || board.read_permission === 'author';
+
   const isBoardLocked = (board: Board): boolean =>
-    (board.read_permission === 'member' && !accessToken) ||
+    (requiresLogin(board) && !accessToken) ||
     (board.read_permission === 'staff' && !(user?.is_staff));
 
   const handleBoardClick = (board: Board) => {
-    if (board.read_permission === 'member' && !accessToken) {
+    if (requiresLogin(board) && !accessToken) {
       showAlert({ message: '회원 전용 게시판입니다. 로그인 후 이용해주세요.', type: 'warning' });
       handleNavigate("/signin");
       return;

--- a/src/Components/Utils/Sidebar.tsx
+++ b/src/Components/Utils/Sidebar.tsx
@@ -35,12 +35,16 @@ const Sidebar: React.FC<SidebarProps> = ({
     const { showAlert } = useAlert();
 
     // read_permission 미지정은 'all'(전체공개)로 취급해 하위호환 유지
+    // 'author'(본인+스태프) 게시판은 진입 자체는 회원 전체에게 열린다(제출·본인 글 확인용).
+    const requiresLogin = (board: Board): boolean =>
+        board.read_permission === 'member' || board.read_permission === 'author';
+
     const isBoardLocked = (board: Board): boolean =>
-        (board.read_permission === 'member' && !accessToken) ||
+        (requiresLogin(board) && !accessToken) ||
         (board.read_permission === 'staff' && !(user?.is_staff));
 
     const handleBoardClick = (board: Board) => {
-        if (board.read_permission === 'member' && !accessToken) {
+        if (requiresLogin(board) && !accessToken) {
             showAlert({ message: '회원 전용 게시판입니다. 로그인 후 이용해주세요.', type: 'warning' });
             navigate("/signin");
             return;

--- a/src/Components/Utils/interfaces.tsx
+++ b/src/Components/Utils/interfaces.tsx
@@ -113,8 +113,8 @@ export interface Board {
     form_type?: number;
     available_tags?: string[];
     latest_post_created_at?: string | null;
-    // 공개범위: 'all'(전체공개) | 'member'(회원전용) | 'staff'(스태프전용)
-    read_permission?: 'all' | 'member' | 'staff';
+    // 공개범위: 'all'(전체공개) | 'member'(회원전용) | 'author'(본인+스태프) | 'staff'(스태프전용)
+    read_permission?: 'all' | 'member' | 'author' | 'staff';
 }
 
 // 모집 시스템 관련 인터페이스


### PR DESCRIPTION
## 요약
- 관리자 페이지 게시판 관리를 **조회/작성/댓글 3컬럼 매트릭스**로 개편 (낙관적 업데이트+실패 롤백 유지)
- 'author'(본인+스태프) 조회 스코프 대응: 사이드바·모바일 내비에서 비로그인 시 로그인 유도, 글쓰기/상세 화면에 본인+스태프 안내 표시
- 고정 게시판(사진첩=전체공개, 사유서형=본인+스태프)은 select 잠금 + 사유 안내
- `updateBoardReadPermission` → `updateBoardPermissions`(부분 PATCH)로 교체

## 테스트
- `npx tsc --noEmit` 통과

## 의존
- 백엔드 PR: dev-JBIG/jbig_backend#36 이 먼저 배포되어야 함 (author 값·매트릭스 PATCH API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)