### PR TITLE
프로필 활동 탭 영구 로딩 수정

### DIFF
--- a/src/Components/Profile/Profile.tsx
+++ b/src/Components/Profile/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useMemo, lazy, Suspense } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from "react";
 import { useParams, useNavigate, useLocation, useSearchParams } from "react-router-dom";
 import { useUser } from "../Utils/UserContext";
 import { fetchPublicProfile, fetchPublicProfileActivity, updateProfileBlocks, updateProfileHtml, PublicProfile, deleteAccount } from "../../API/req";
@@ -45,6 +45,7 @@ const Profile: React.FC = () => {
     const [loading, setLoading] = useState(true);
     const [activityLoading, setActivityLoading] = useState(false);
     const [activityLoaded, setActivityLoaded] = useState(false);
+    const activityFetchingRef = useRef(false);
     const [error, setError] = useState<string | null>(null);
 
     const [editMode, setEditMode] = useState(false);
@@ -93,7 +94,12 @@ const Profile: React.FC = () => {
     }, [loadProfile]);
 
     useEffect(() => {
-        if (tab !== 'activity' || !username || !profile || activityLoaded || activityLoading) return;
+        if (tab !== 'activity' || !username || !profile || activityLoaded) return;
+        // 인플라이트 가드는 state가 아니라 ref로 관리한다. activityLoading을 의존성에
+        // 넣으면 setActivityLoading(true)가 이펙트를 재실행시켜 cleanup이 첫 요청을
+        // cancelled 처리하고, finally의 로딩 해제까지 건너뛰어 영구 로딩에 빠진다.
+        if (activityFetchingRef.current) return;
+        activityFetchingRef.current = true;
 
         let cancelled = false;
         setActivityLoading(true);
@@ -113,13 +119,14 @@ const Profile: React.FC = () => {
                 showAlert({ message: "활동을 불러오는데 실패했습니다.", type: 'error' });
             })
             .finally(() => {
-                if (!cancelled) setActivityLoading(false);
+                activityFetchingRef.current = false;
+                setActivityLoading(false);
             });
 
         return () => {
             cancelled = true;
         };
-    }, [tab, username, profile, activityLoaded, activityLoading, accessToken, showAlert]);
+    }, [tab, username, profile, activityLoaded, accessToken, showAlert]);
 
     const handleSaveBlocks = async (blocks: ProfileBlock[]) => {
         if (!accessToken) return;


### PR DESCRIPTION
## 원인
활동 탭 useEffect의 의존성 배열에 `activityLoading`이 포함되어 자기-취소 데드락 발생:
1. 이펙트가 `setActivityLoading(true)` → 의존성 변경으로 이펙트 재실행
2. cleanup이 첫 요청의 `cancelled = true` 처리
3. fetch가 성공해도 `if (!cancelled)` 가드 때문에 `setActivityLoading(false)`를 건너뜀
4. → "불러오는 중..." 영구 표시

## 수정
- 인플라이트 가드를 state 대신 `useRef`로 관리 (의존성 배열에서 `activityLoading` 제거)
- `finally`에서 로딩 상태를 무조건 해제

## 테스트
- `npx tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)